### PR TITLE
remove qt-5.9.7-h468cd18_0 from index

### DIFF
--- a/main.py
+++ b/main.py
@@ -29,7 +29,10 @@ SUBDIRS = (
 REMOVALS = {
     "noarch": (),
     "linux-ppc64le": [],
-    "osx-64": [],
+    "osx-64": [
+        # qt 5.9.7 accidentially added .conda. to the dylibs names
+        'qt-5.9.7-h468cd18_0.tar.bz2',
+        ],
     "win-32": ["nomkl-*"],
     "win-64": ["nomkl-*"],
     "any": {


### PR DESCRIPTION
Remove the qt-5.9.7-h468cd18_0.tar.bz2 package from the osx-64 index.
This package contains dylibs with .conda. added to the name which are
incompatible with earlier qt 5.9 releases and downstream packages.