### PR TITLE
fix unpinned mro-base dep; add test tool

### DIFF
--- a/r.py
+++ b/r.py
@@ -5,6 +5,7 @@ from collections import defaultdict
 import json
 import os
 from os.path import join, dirname, isfile, isdir
+import re
 import sys
 import fnmatch
 
@@ -177,6 +178,24 @@ def _patch_repodata(repodata, subdir):
         if (any(fnmatch.fnmatch(fn, rev) for rev in REMOVALS.get(subdir, [])) or
                  any(fnmatch.fnmatch(fn, rev) for rev in REMOVALS.get("any", []))):
             instructions['remove'].append(fn)
+
+        if any(dep == 'mro-base' for dep in record.get('depends', [])):
+            deps = record['depends']
+            deps.remove('mro-base')
+            version = re.search(".*\-mro(\d{3})", fn).group(1)
+            lb = '.'.join((_ for _ in version))
+            ub = '.'.join((_ for _ in str(int(version) + 10)))
+            ub = '.'.join(ub.split('.')[:2] + ['0'])
+            deps.append("mro-base >={},<{}a0".format(lb, ub))
+
+        if any(dep == 'r-base' for dep in record.get('depends', [])):
+            deps = record['depends']
+            deps.remove('r-base')
+            version = re.search(".*\-r(\d{3})", fn).group(1)
+            lb = '.'.join((_ for _ in version))
+            ub = '.'.join((_ for _ in str(int(version) + 10)))
+            ub = '.'.join(ub.split('.')[:2] + ['0'])
+            deps.append("r-base >={},<{}a0".format(lb, ub))
 
     return instructions
 

--- a/r.py
+++ b/r.py
@@ -11,7 +11,7 @@ import fnmatch
 
 import requests
 
-CHANNEL_NAME = "pro"
+CHANNEL_NAME = "r"
 CHANNEL_ALIAS = "https://repo.anaconda.com/pkgs"
 SUBDIRS = (
     "noarch",
@@ -118,14 +118,16 @@ NAMESPACE_OVERRIDES = {
 
 
 def _patch_repodata(repodata, subdir):
-    index = repodata["packages"]
     instructions = {
         "patch_instructions_version": 1,
         "packages": defaultdict(dict),
         "revoke": [],
         "remove": [],
     }
+    if 'packages' not in repodata:
+        return instructions
 
+    index = repodata["packages"]
     instructions["remove"].extend(REMOVALS.get(subdir, ()))
 
     if subdir == "noarch":
@@ -154,21 +156,27 @@ def _patch_repodata(repodata, subdir):
         # ensure that all r/r-base/mro-base packages have the mutex
         if record_name == "r-base":
             if not any(dep.split()[0] == "_r_mutex" for dep in record['depends']):
-                record['depends'].append("_r-mutex 1.* anacondar_1")
+                if "_r-mutex 1.* anacondar_1" not in record['depends']:
+                    record['depends'].append("_r-mutex 1.* anacondar_1")
                 instructions["packages"][fn]["depends"] = record['depends']
         elif record_name == "mro-base":
             if not any(dep.split()[0] == "_r_mutex" for dep in record['depends']):
-                record['depends'].append("_r-mutex 1.* mro_2")
+                if "_r-mutex 1.* mro_2" not in record['depends']:
+                    record['depends'].append("_r-mutex 1.* mro_2")
                 instructions["packages"][fn]["depends"] = record['depends']
         # None of the 3.1.2 builds used r-base, and none of them have the mutex
         elif record_name == "r" and record['version'] == "3.1.2":
             # less than build 3 was an actual package; no r-base connection.  These need the mutex.
             if int(record["build_number"]) < 3:
-                record['depends'].append("_r-mutex 1.* anacondar_1")
+                if "_r-mutex 1.* anacondar_1" not in record['depends']:
+                    record['depends'].append("_r-mutex 1.* anacondar_1")
                 instructions["packages"][fn]["depends"] = record['depends']
             else:
                 # this dep was underspecified
-                record['depends'].remove('r-base')
+                try:
+                    record['depends'].remove('r-base')
+                except ValueError:
+                    pass
                 record['depends'].append('r-base 3.1.2')
                 instructions["packages"][fn]["depends"] = record['depends']
 
@@ -182,20 +190,22 @@ def _patch_repodata(repodata, subdir):
         if any(dep == 'mro-base' for dep in record.get('depends', [])):
             deps = record['depends']
             deps.remove('mro-base')
-            version = re.search(".*\-mro(\d{3})", fn).group(1)
+            version = re.search(r".*\-.*mro(\d{3})", fn).group(1)
             lb = '.'.join((_ for _ in version))
             ub = '.'.join((_ for _ in str(int(version) + 10)))
             ub = '.'.join(ub.split('.')[:2] + ['0'])
             deps.append("mro-base >={},<{}a0".format(lb, ub))
+            instructions["packages"][fn]["depends"] = deps
 
         if any(dep == 'r-base' for dep in record.get('depends', [])):
             deps = record['depends']
             deps.remove('r-base')
-            version = re.search(".*\-r(\d{3})", fn).group(1)
+            version = re.search(r".*\-.*r(\d{3})", fn).group(1)
             lb = '.'.join((_ for _ in version))
             ub = '.'.join((_ for _ in str(int(version) + 10)))
             ub = '.'.join(ub.split('.')[:2] + ['0'])
             deps.append("r-base >={},<{}a0".format(lb, ub))
+            instructions["packages"][fn]["depends"] = deps
 
     return instructions
 
@@ -240,6 +250,7 @@ def main():
     patch_instructions = {}
     for subdir in SUBDIRS:
         instructions = _patch_repodata(repodatas[subdir], subdir)
+
         patch_instructions_path = join(base_dir, subdir, "patch_instructions.json")
         with open(patch_instructions_path, 'w') as fh:
             json.dump(instructions, fh, indent=2, sort_keys=True, separators=(',', ': '))

--- a/test-hotfix.py
+++ b/test-hotfix.py
@@ -1,0 +1,58 @@
+import json
+import os
+import difflib
+import subprocess
+
+from six.moves import urllib
+from conda.exports import subdir
+from conda_build.index import _apply_instructions
+
+html_differ = difflib.HtmlDiff()
+diff_options = {'unified': difflib.unified_diff,
+                'context': difflib.context_diff,
+                'html': html_differ.make_file}
+diff_context_keyword = {'unified': 'n',
+                        'context': 'n',
+                        'html': 'numlines'}
+
+channel_map = {
+    'main': 'https://repo.anaconda.com/pkgs/main',
+    'r': 'https://repo.anaconda.com/pkgs/r',
+}
+
+
+def clone_subdir(channel_base_url, subdir):
+    out_file = os.path.join(channel_base_url.rsplit('/', 1)[-1], subdir, 'repodata-clone.json')
+    url = "%s/%s/repodata.json" % (channel_base_url, subdir)
+    print("downloading repodata from {}".format(url))
+    urllib.request.urlretrieve(url, out_file)
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='Process some integers.')
+    parser.add_argument('channel', help='channel name or url to download repodata from')
+    parser.add_argument('--subdir', help='subdir to download/diff', default=subdir)
+    parser.add_argument('--diff-format', help='format to save diff as',
+                        choices=('unified', 'context', 'html'), default='html')
+    parser.add_argument('--context-numlines', help='context lines to show around diff',
+                        type=int, default=5)
+    args = parser.parse_args()
+
+    if not os.path.isdir(os.path.join(args.channel, args.subdir)):
+        os.makedirs(os.path.join(args.channel, args.subdir))
+    if '/' not in args.channel:
+        channel_base_url = channel_map[args.channel]
+    clone_subdir(channel_base_url, args.subdir)
+    subprocess.check_call(['python', args.channel + '.py'])
+    repodata_file = os.path.join(args.channel, args.subdir, 'repodata-clone.json')
+    with open(repodata_file) as f:
+        repodata = json.load(f)
+    out_instructions = os.path.join(args.channel, args.subdir, 'patch_instructions.json')
+    with open(out_instructions) as f:
+        instructions = json.load(f)
+    patched_repodata = _apply_instructions(args.subdir, repodata, instructions)
+    patched_repodata_file = os.path.join(args.channel, args.subdir, 'repodata-patched.json')
+    with open(patched_repodata_file, 'w') as f:
+        json.dump(patched_repodata, f, indent=2, sort_keys=True, separators=(',', ': '))
+    subprocess.call(['diff', repodata_file, patched_repodata_file])


### PR DESCRIPTION
test tool shows you a diff of what your current changes do.

```
python test-hotfix.py r --subdir=linux-64
```

Note that it's a diff from whatever the remote is.  If the remote has the same patches applied that you have locally, it should show nothing.  It should only show changes that you have relative to what is deployed.