### PR TITLE
revoke bad build of libssh2 (osx-64)

### DIFF
--- a/main.py
+++ b/main.py
@@ -75,6 +75,8 @@ REVOKED = {
         # this build statically links libxml2-with-icu but doesn't statically
         # link icu. xref: https://github.com/AnacondaRecipes/aggregate/issues/10
         "xar-1.6.1-hd3d9906_0.tar.bz2",
+        # doesn't specify dependency on openssl, whereas it should
+        "libssh2 1.8.0 h1218725_2",
         ],
     "win-32": [
         "spyder-kernels-1.0.1-*_0"


### PR DESCRIPTION
```
(base) ➜  ~ conda search \
    --info \
    'libssh2[subdir=osx-64,version=1.8.0,build=h1218725_2]' \
    | grep dependencies
dependencies: []
```