### PR TITLE
add index_versions.yml file for indexing additional current repodata

### DIFF
--- a/index_versions.yml
+++ b/index_versions.yml
@@ -1,0 +1,2 @@
+anaconda:
+  - custom


### PR DESCRIPTION
This goes with conda-build's current_repodata.json.  Any entries here are ensured to stay in the trimmed repodata.  The newest version is implicit and does not need to be supplied.