### PR TITLE
main.py: fix typo in TFLOW_SUBS

### DIFF
--- a/main.py
+++ b/main.py
@@ -93,7 +93,7 @@ TFLOW_SUBS = {
     # 1.8.0, eigen is the default variant
     '_tflow_180_select ==1.0 gpu': '_tflow_select ==1.1.0 gpu',
     '_tflow_180_select ==2.0 mkl': '_tflow_select ==1.2.0 mkl',
-    '_tflow_180_select ==3.0 eigen': '_tflow_select ==1.2.0 eigen',
+    '_tflow_180_select ==3.0 eigen': '_tflow_select ==1.3.0 eigen',
 
     # 1.9.0, mkl is the default variant
     '_tflow_190_select ==0.0.1 gpu': '_tflow_select ==2.1.0 gpu',


### PR DESCRIPTION
This is causing problems for me:

```
PackagesNotFoundError: The following packages are not available from current channels:

  - pkgs/main/linux-64::tensorflow==1.8.0=h7b2774c_0 -> _tflow_select==1.2.0=eigen

```

See also https://github.com/conda/conda/issues/8863#issuecomment-510394224