### PR TITLE
revoke libarchive 3.3.3 build 0

### DIFF
--- a/main.py
+++ b/main.py
@@ -79,12 +79,14 @@ REVOKED = {
         "libssh2 1.8.0 h1218725_2",
         ],
     "win-32": [
-        "spyder-kernels-1.0.1-*_0"
+        "spyder-kernels-1.0.1-*_0",
     ],
     "win-64": [
-        "spyder-kernels-1.0.1-*_0"
+        "spyder-kernels-1.0.1-*_0",
     ],
-    "any": []
+    "any": [
+        "libarchive-3.3.3-*_0",
+    ]
 }
 
 BLAS_USING_PKGS = {"numpy", "numpy-base", "scipy", "numexpr", "scikit-learn", "libmxnet"}


### PR DESCRIPTION
this build has missing dependencies and is causing people problems.  Build 1 or newer should be preferred in all cases.