### PR TITLE
add python-libarchive-c to cb 3.18, because CPH 1.5+ no longer depend…

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,6 +155,10 @@ def _replace_vc_features_with_vc_pkg_deps(fn, record, instructions):
                 new_deps.append("conda >=4.5")
             else:
                 new_deps.append(dep)
+        # CPH 1.5 has a statically linked libarchive and doesn't depend on python-libarchive-c
+        #    we were implicitly depending on it, and it goes missing.
+        if "python-libarchive-c" not in new_deps:
+            new_deps.append('python-libarchive-c')
         instructions["packages"][fn]['depends'] = new_deps
     elif record['name'] == "yasm":
         # remove vc from the features key


### PR DESCRIPTION
…s on it, but cb does