### PR TITLE
remove numba 0.46 py38 builds

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,7 +34,12 @@ REMOVALS = {
         'qt-5.9.7-h468cd18_0.tar.bz2',
         ],
     "win-32": ["nomkl-*"],
-    "win-64": ["nomkl-*"],
+    "win-64": ["nomkl-*",
+               # numba 0.46 didn't actually support py38
+              "numba-0.46.0-py38hf9181ef_0.tar.bz2",
+              ],
+    "linux-64": [
+        "numba-0.46.0-py38h962f231_0.tar.bz2",
     "any": {
         # early efforts on splitting numpy recipe did not pin numpy-base exactly.
         #     These led to bad builds (built against newest numpy)


### PR DESCRIPTION
numba is not compatible with py38 yet.