### PR TITLE
change upper bound on spyder-kernel req to 1.9.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -641,6 +641,10 @@ def _patch_repodata(repodata, subdir):
                     add_parso_dep = False
                 if dep.startswith('psutil'):
                     record['depends'][idx] = "psutil >=5.2"
+                # spyder-kernels needs to be pinned to <=1.9.0, see:
+                # https://github.com/conda-forge/spyder-feedstock/pull/76
+                if dep.startswith('spyder-kernels'):
+                    record['depends'][idx] = 'spyder-kernels >=1.8.1,<1.9.0'
             if add_parso_dep:
                 record['depends'].append("parso 0.5.2.*")
             instructions["packages"][fn]["depends"] = record["depends"]


### PR DESCRIPTION
Change the upper bound on the spyder-kernels requirement for the
spyder 4.0.0 and 4.0.1 packages to 1.9.0 from 2.0.0