### PR TITLE
hotfix libffi to account for 3.3 ABI breakage

### DIFF
--- a/main.py
+++ b/main.py
@@ -882,6 +882,15 @@ def _patch_repodata(repodata, subdir):
                 record['depends'][ujson_idx] = 'ujson <=1.35'
                 instructions["packages"][fn]["depends"] = record["depends"]
 
+        # libffi broke ABI compatibility in 3.3
+        if 'libffi >=3.2.1,<4.0a0' in record['depends'] or 'libffi' in record['depends']:
+            if 'libffi >=3.2.1,<4.0a0' in record['depends']:
+                libffi_idx = record['depends'].index('libffi >=3.2.1,<4.0a0')
+            else:
+                libffi_idx = record['depends'].index('libffi')
+            record['depends'][libffi_idx] = 'libffi >=3.2.1,<3.3a0'
+            instructions["packages"][fn]["depends"] = record["depends"]
+
     instructions['remove'].sort()
     instructions['revoke'].sort()
     return instructions


### PR DESCRIPTION
libffi broke ABI with the 3.3 release:
https://abi-laboratory.pro/index.php?view=objects_report&l=libffi&v1=3.2.1&v2=3.3
Adjust the bounds for packages which depend on libffi to have an upper
bound of <3.3a0.