### PR TITLE
Refactor

### DIFF
--- a/main.py
+++ b/main.py
@@ -577,22 +577,25 @@ def patch_record(fn, record, subdir, instructions, index):
                 depends.append(MKL_VERSION_2018_EXTENDED_RC.sub('%s,<2019.0a0'%(dep.split()[1]), dep))
         instructions["packages"][fn]["depends"] = depends
 
-    #
+    # store changes to dependencies up to this point
+    # TODO this is not needed once the above is merged into patch_record_in_place
     depends = _get_record_depends(fn, record, instructions)
     record['depends'] = depends
 
+    # create a copy of the record, patch in-place and add keys that change
+    # to the patch instructions
     original_record = copy.deepcopy(record)
     patch_record_in_place(fn, record, subdir)
-
-    # TODO copy more keys over if they differ
     keys_to_check = ['depends']  # TODO add more keys here
     for key in keys_to_check:
         if record.get(key) != original_record.get(key):
             instructions["packages"][fn][key] = record.get(key)
 
+    # these undo some changes already made.
+    # TODO reviewed the changes and undo
     if subdir == "osx-64":
         _fix_osx_libgfortan_bounds(fn, record, instructions)
-    # TODO this un-does libgfortran fixes needs to be after _fix_osx_libgfortan_bounds
+    # this un-does libgfortran fixes, needs to be after _fix_osx_libgfortan_bounds
     _fix_libnetcdf_upper_bound(fn, record, instructions)
 
 

--- a/main.py
+++ b/main.py
@@ -951,7 +951,7 @@ def do_hotfixes(base_dir):
             with open(repodata_path) as fh:
                 repodatas[subdir] = json.load(fh)
         else:
-            repodata_url = "/".join((CHANNEL_ALIAS, CHANNEL_NAME, subdir, "repodata.json"))
+            repodata_url = "/".join((CHANNEL_ALIAS, CHANNEL_NAME, subdir, "repodata_from_packages.json"))
             response = requests.get(repodata_url)
             response.raise_for_status()
             repodatas[subdir] = response.json()

--- a/main.py
+++ b/main.py
@@ -489,6 +489,13 @@ def _patch_repodata(repodata, subdir):
         }
 
     for fn, record in index.items():
+        if (any(fnmatch.fnmatch(fn, rev) for rev in REVOKED.get(subdir, [])) or
+                    any(fnmatch.fnmatch(fn, rev) for rev in REVOKED.get("any", []))):
+            instructions['revoke'].append(fn)
+        if (any(fnmatch.fnmatch(fn, rev) for rev in REMOVALS.get(subdir, [])) or
+                    any(fnmatch.fnmatch(fn, rev) for rev in REMOVALS.get("any", []))):
+            instructions['remove'].append(fn)
+        _apply_namespace_overrides(fn, record, instructions)
         patch_record(fn, record, subdir, instructions, index)
     instructions['remove'].sort()
     instructions['revoke'].sort()
@@ -501,13 +508,6 @@ def patch_record(fn, record, subdir, instructions, index):
     build_number = record['build_number']
     depends = record['depends']
 
-    if (any(fnmatch.fnmatch(fn, rev) for rev in REVOKED.get(subdir, [])) or
-                any(fnmatch.fnmatch(fn, rev) for rev in REVOKED.get("any", []))):
-        instructions['revoke'].append(fn)
-    if (any(fnmatch.fnmatch(fn, rev) for rev in REMOVALS.get(subdir, [])) or
-                any(fnmatch.fnmatch(fn, rev) for rev in REMOVALS.get("any", []))):
-        instructions['remove'].append(fn)
-    _apply_namespace_overrides(fn, record, instructions)
     if fn.startswith("numba-0.36.1") and record.get('timestamp') != 1512604800000:
         # set a specific timestamp
         instructions["packages"][fn]['timestamp'] = 1512604800000

--- a/main.py
+++ b/main.py
@@ -966,6 +966,16 @@ def do_hotfixes(base_dir):
     patch_instructions = {}
     for subdir in SUBDIRS:
         instructions = _patch_repodata(repodatas[subdir], subdir)
+        # TODO remove this
+        conda_instructions = {}
+        for pkg, info in instructions["packages"].items():
+            if "features" in info and info["features"] == None:
+                conda_info = info.copy()
+                conda_info['features'] = "nomkl"
+                conda_pkg = pkg.replace('.tar.bz2', '.conda')
+                conda_instructions[conda_pkg] = conda_info
+                #import pdb; pdb.set_trace()
+        instructions["packages.conda"] = conda_instructions
         patch_instructions_path = join(base_dir, subdir, "patch_instructions.json")
         with open(patch_instructions_path, 'w') as fh:
             json.dump(instructions, fh, indent=2, sort_keys=True, separators=(',', ': '))

--- a/main.py
+++ b/main.py
@@ -375,6 +375,7 @@ def _fix_libnetcdf_upper_bound(fn, record, instructions):
 def _fix_nomkl_features(fn, record, instructions):
     if "nomkl" == record["features"]:
         del record['features']
+        instructions["packages"][fn]["features"] = None
         if not any(d.startswith("blas ") for d in record["depends"]):
             instructions["packages"][fn]["depends"] = record['depends'] + ["blas * openblas"]
     elif "nomkl" in record["features"]:

--- a/main.py
+++ b/main.py
@@ -946,7 +946,7 @@ def do_hotfixes(base_dir):
     # Step 1. Collect initial repodata for all subdirs.
     repodatas = {}
     for subdir in SUBDIRS:
-        repodata_path = join(base_dir, subdir, 'repodata-clone.json')
+        repodata_path = join(base_dir, subdir, 'repodata_from_packages.json')
         if isfile(repodata_path):
             with open(repodata_path) as fh:
                 repodatas[subdir] = json.load(fh)

--- a/test-hotfix.py
+++ b/test-hotfix.py
@@ -37,28 +37,34 @@ if __name__ == "__main__":
     import argparse
     parser = argparse.ArgumentParser(description='Process some integers.')
     parser.add_argument('channel', help='channel name or url to download repodata from')
-    parser.add_argument('--subdir', help='subdir to download/diff', default=subdir)
+    parser.add_argument('--subdirs', nargs='*', help='subdir(s) to download/diff', default=(subdir, ))
     parser.add_argument('--diff-format', help='format to save diff as',
                         choices=('unified', 'context', 'html'), default='html')
     parser.add_argument('--context-numlines', help='context lines to show around diff',
                         type=int, default=5)
+    parser.add_argument('--use-cache', action='store_true', help='use cached repodata')
     args = parser.parse_args()
 
-    if not os.path.isdir(os.path.join(args.channel, args.subdir)):
-        os.makedirs(os.path.join(args.channel, args.subdir))
+    for subdir in args.subdirs:
+        if not os.path.isdir(os.path.join(args.channel, subdir)):
+            os.makedirs(os.path.join(args.channel, subdir))
     if '/' not in args.channel:
         channel_base_url = channel_map[args.channel]
-    clone_subdir(channel_base_url, args.subdir)
+    if not args.use_cache:
+        for subdir in args.subdirs:
+            clone_subdir(channel_base_url, subdir)
     subprocess.check_call(['python', args.channel + '.py'])
-    raw_repodata_file = os.path.join(args.channel, args.subdir, 'repodata_from_packages.json')
-    ref_repodata_file = os.path.join(args.channel, args.subdir, 'reference_repodata.json')
-    with open(raw_repodata_file) as f:
-        repodata = json.load(f)
-    out_instructions = os.path.join(args.channel, args.subdir, 'patch_instructions.json')
-    with open(out_instructions) as f:
-        instructions = json.load(f)
-    patched_repodata = _apply_instructions(args.subdir, repodata, instructions)
-    patched_repodata_file = os.path.join(args.channel, args.subdir, 'repodata-patched.json')
-    with open(patched_repodata_file, 'w') as f:
-        json.dump(patched_repodata, f, indent=2, sort_keys=True, separators=(',', ': '))
-    subprocess.call(['colordiff', ref_repodata_file, patched_repodata_file])
+    for subdir in args.subdirs:
+        print(subdir, "\n---------------")
+        raw_repodata_file = os.path.join(args.channel, subdir, 'repodata_from_packages.json')
+        ref_repodata_file = os.path.join(args.channel, subdir, 'reference_repodata.json')
+        with open(raw_repodata_file) as f:
+            repodata = json.load(f)
+        out_instructions = os.path.join(args.channel, subdir, 'patch_instructions.json')
+        with open(out_instructions) as f:
+            instructions = json.load(f)
+        patched_repodata = _apply_instructions(subdir, repodata, instructions)
+        patched_repodata_file = os.path.join(args.channel, subdir, 'repodata-patched.json')
+        with open(patched_repodata_file, 'w') as f:
+            json.dump(patched_repodata, f, indent=2, sort_keys=True, separators=(',', ': '))
+        subprocess.call(['colordiff', ref_repodata_file, patched_repodata_file])

--- a/test-hotfix.py
+++ b/test-hotfix.py
@@ -55,7 +55,6 @@ if __name__ == "__main__":
             clone_subdir(channel_base_url, subdir)
     subprocess.check_call(['python', args.channel + '.py'])
     for subdir in args.subdirs:
-        print(subdir, "\n---------------")
         raw_repodata_file = os.path.join(args.channel, subdir, 'repodata_from_packages.json')
         ref_repodata_file = os.path.join(args.channel, subdir, 'reference_repodata.json')
         with open(raw_repodata_file) as f:
@@ -67,4 +66,4 @@ if __name__ == "__main__":
         patched_repodata_file = os.path.join(args.channel, subdir, 'repodata-patched.json')
         with open(patched_repodata_file, 'w') as f:
             json.dump(patched_repodata, f, indent=2, sort_keys=True, separators=(',', ': '))
-        subprocess.call(['colordiff', ref_repodata_file, patched_repodata_file])
+        subprocess.call(['colordiff', '-w', ref_repodata_file, patched_repodata_file])

--- a/test-hotfix.py
+++ b/test-hotfix.py
@@ -23,11 +23,15 @@ channel_map = {
 
 
 def clone_subdir(channel_base_url, subdir):
-    out_file = os.path.join(channel_base_url.rsplit('/', 1)[-1], subdir, 'repodata-clone.json')
+    out_file = os.path.join(channel_base_url.rsplit('/', 1)[-1], subdir, 'reference_repodata.json')
     url = "%s/%s/repodata.json" % (channel_base_url, subdir)
     print("downloading repodata from {}".format(url))
     urllib.request.urlretrieve(url, out_file)
 
+    out_file = os.path.join(channel_base_url.rsplit('/', 1)[-1], subdir, 'repodata_from_packages.json')
+    url = "%s/%s/repodata_from_packages.json" % (channel_base_url, subdir)
+    print("downloading repodata from {}".format(url))
+    urllib.request.urlretrieve(url, out_file)
 
 if __name__ == "__main__":
     import argparse
@@ -46,8 +50,9 @@ if __name__ == "__main__":
         channel_base_url = channel_map[args.channel]
     clone_subdir(channel_base_url, args.subdir)
     subprocess.check_call(['python', args.channel + '.py'])
-    repodata_file = os.path.join(args.channel, args.subdir, 'repodata-clone.json')
-    with open(repodata_file) as f:
+    raw_repodata_file = os.path.join(args.channel, args.subdir, 'repodata_from_packages.json')
+    ref_repodata_file = os.path.join(args.channel, args.subdir, 'reference_repodata.json')
+    with open(raw_repodata_file) as f:
         repodata = json.load(f)
     out_instructions = os.path.join(args.channel, args.subdir, 'patch_instructions.json')
     with open(out_instructions) as f:
@@ -56,4 +61,4 @@ if __name__ == "__main__":
     patched_repodata_file = os.path.join(args.channel, args.subdir, 'repodata-patched.json')
     with open(patched_repodata_file, 'w') as f:
         json.dump(patched_repodata, f, indent=2, sort_keys=True, separators=(',', ': '))
-    subprocess.call(['diff', repodata_file, patched_repodata_file])
+    subprocess.call(['colordiff', ref_repodata_file, patched_repodata_file])


### PR DESCRIPTION
Refactor patching of main and the testing script.  
Patching is done in-place on the `record` object so that patches of patches are automatically applied.  The final patch instructions are generated by comparing the contents of a record with a reference prior to any modification.  Path instructions are only generated if these differ.  

The `test-hotfix.py` script was modified to work from the `repodata_from_packages.json` file in the same manner as is done when `conda index` is run.  The difference between the local results of patching and patched repodata.json files in the package repository are displayed for one or more subdirs.