### PR TITLE
Fix dependencies for dask-core, dask 2021.3.1

### DIFF
--- a/main.py
+++ b/main.py
@@ -764,6 +764,14 @@ def patch_record_in_place(fn, record, subdir):
     if fn == "dask-core-2.7.0-py_0.tar.bz2":
         depends[:] = ['python >=3.6']
 
+    if (name == 'dask-core' and version == '2021.3.1' and build_number == 0):
+        depends[:] = ['python >=3.7', 'cloudpickle >=1.1.1', 'fsspec >=0.6.0',
+                      'partd >= 0.3.10', 'pyyaml', 'toolz >=0.8.2']
+    if (name == 'dask' and version == '2021.3.1' and build_number == 0):
+        depends[:] = ['python >=3.7'] + [d for d in depends if d.split(' ')[0]
+            not in ('python', 'cloudpickle', 'fsspec', 'partd', 'toolz')]
+        depends.sort()
+
     # sparkmagic <=0.12.7 has issues with ipykernel >4.10
     # see: https://github.com/AnacondaRecipes/sparkmagic-feedstock/pull/3
     if name == 'sparkmagic' and version in ['0.12.1', '0.12.5', '0.12.6', '0.12.7']:


### PR DESCRIPTION
Fixes AnacondaRecipes/repodata-hotfixes#103.

diff output from `python test-hotfix.py main --subdir noarch`:
```
--- main/noarch/reference_repodata.json	2021-04-02 13:34:38.691185038 -0500
+++ main/noarch/repodata-patched.json	2021-04-02 13:38:28.023150358 -0500
@@ -14560,26 +14560,22 @@
     "dask-2021.3.1-pyhd3eb1b0_0.tar.bz2": {
       "build": "pyhd3eb1b0_0",
       "build_number": 0,
       "constrains": [
         "openssl !=1.1.1e"
       ],
       "depends": [
         "bokeh >=1.0.0,!=2.0.0",
-        "cloudpickle >=0.2.2",
         "cytoolz >=0.8.2",
         "dask-core 2021.3.1.*",
         "distributed >=2021.3.1",
-        "fsspec >=0.6.0",
         "numpy >=1.15.1",
         "pandas >=0.25.0",
-        "partd >=0.3.10",
-        "python >=3.6",
-        "toolz >=0.8.2"
+        "python >=3.7"
       ],
       "license": "BSD-3-Clause",
       "md5": "630e2511f4639702428de14ed89cbe45",
       "name": "dask",
       "noarch": "python",
       "sha256": "ef9d6a6764302644d0f64067d4c2c074e0bb08f372bc1fcd88414bb412c3c5d9",
       "size": 4738,
       "subdir": "noarch",
@@ -15387,18 +15383,22 @@
       "subdir": "noarch",
       "timestamp": 1615055157183,
       "version": "2021.3.0"
     },
     "dask-core-2021.3.1-pyhd3eb1b0_0.tar.bz2": {
       "build": "pyhd3eb1b0_0",
       "build_number": 0,
       "depends": [
-        "python >=3.6",
-        "pyyaml"
+        "python >=3.7",
+        "cloudpickle >=1.1.1",
+        "fsspec >=0.6.0",
+        "partd >= 0.3.10",
+        "pyyaml",
+        "toolz >=0.8.2"
       ],
       "license": "BSD-3-Clause",
       "md5": "354c8113fa8f1e3eb1f18cec0653ccd2",
       "name": "dask-core",
       "noarch": "python",
       "sha256": "ab07520f2ad40ac3a3c85f99b37a1988ab583d3aa1878d3c1ec3405e9418db88",
       "size": 729308,
       "subdir": "noarch",
@@ -76902,26 +76902,22 @@
     "dask-2021.3.1-pyhd3eb1b0_0.conda": {
       "build": "pyhd3eb1b0_0",
       "build_number": 0,
       "constrains": [
         "openssl !=1.1.1e"
       ],
       "depends": [
         "bokeh >=1.0.0,!=2.0.0",
-        "cloudpickle >=0.2.2",
         "cytoolz >=0.8.2",
         "dask-core 2021.3.1.*",
         "distributed >=2021.3.1",
-        "fsspec >=0.6.0",
         "numpy >=1.15.1",
         "pandas >=0.25.0",
-        "partd >=0.3.10",
-        "python >=3.6",
-        "toolz >=0.8.2"
+        "python >=3.7"
       ],
       "license": "BSD-3-Clause",
       "md5": "e6220d4db0f04a490c3b15df573b8826",
       "name": "dask",
       "noarch": "python",
       "sha256": "06faa7ca39d16b53c4e7b0bd8c3e2d2372edc6d3c220e80b8a6600fa4ce628c4",
       "size": 5083,
       "subdir": "noarch",
@@ -77729,18 +77725,22 @@
       "subdir": "noarch",
       "timestamp": 1615055157183,
       "version": "2021.3.0"
     },
     "dask-core-2021.3.1-pyhd3eb1b0_0.conda": {
       "build": "pyhd3eb1b0_0",
       "build_number": 0,
       "depends": [
-        "python >=3.6",
-        "pyyaml"
+        "python >=3.7",
+        "cloudpickle >=1.1.1",
+        "fsspec >=0.6.0",
+        "partd >= 0.3.10",
+        "pyyaml",
+        "toolz >=0.8.2"
       ],
       "license": "BSD-3-Clause",
       "md5": "b5a2ac00f7870644675a09fd2f6f4435",
       "name": "dask-core",
       "noarch": "python",
       "sha256": "01b156180170d2901ee851a82df4e8eb056a05209fa258b047f9f13c3927cc8d",
       "size": 682920,
       "subdir": "noarch",
```