### PR TITLE
Correct numpy dependency for dask 2021.03.1

### DIFF
--- a/main.py
+++ b/main.py
@@ -768,8 +768,8 @@ def patch_record_in_place(fn, record, subdir):
         depends[:] = ['python >=3.7', 'cloudpickle >=1.1.1', 'fsspec >=0.6.0',
                       'partd >= 0.3.10', 'pyyaml', 'toolz >=0.8.2']
     if (name == 'dask' and version == '2021.3.1' and build_number == 0):
-        depends[:] = ['python >=3.7'] + [d for d in depends if d.split(' ')[0]
-            not in ('python', 'cloudpickle', 'fsspec', 'partd', 'toolz')]
+        depends[:] = ['python >=3.7', 'numpy >=1.16'] + [d for d in depends if d.split(' ')[0]
+            not in ('python', 'cloudpickle', 'fsspec', 'numpy', 'partd', 'toolz')]
         depends.sort()
 
     # sparkmagic <=0.12.7 has issues with ipykernel >4.10


### PR DESCRIPTION
Changes for this hot fix:

```
--- main/noarch/reference_repodata.json	2021-04-02 15:26:32.927886021 -0500
+++ main/noarch/repodata-patched.json	2021-04-02 15:26:39.187777022 -0500
@@ -14624,7 +14624,7 @@
         "cytoolz >=0.8.2",
         "dask-core 2021.3.1.*",
         "distributed >=2021.3.1",
-        "numpy >=1.15.1",
+        "numpy >=1.16",
         "pandas >=0.25.0",
         "python >=3.7"
       ],
@@ -77138,7 +77138,7 @@
         "cytoolz >=0.8.2",
         "dask-core 2021.3.1.*",
         "distributed >=2021.3.1",
-        "numpy >=1.15.1",
+        "numpy >=1.16",
         "pandas >=0.25.0",
         "python >=3.7"
       ],
```
