### PR TITLE
Fix error in dask dependency specification

### DIFF
--- a/main.py
+++ b/main.py
@@ -766,7 +766,7 @@ def patch_record_in_place(fn, record, subdir):
 
     if (name == 'dask-core' and version == '2021.3.1' and build_number == 0):
         depends[:] = ['python >=3.7', 'cloudpickle >=1.1.1', 'fsspec >=0.6.0',
-                      'partd >= 0.3.10', 'pyyaml', 'toolz >=0.8.2']
+                      'partd >=0.3.10', 'pyyaml', 'toolz >=0.8.2']
     if (name == 'dask' and version == '2021.3.1' and build_number == 0):
         depends[:] = ['python >=3.7', 'numpy >=1.16'] + [d for d in depends if d.split(' ')[0]
             not in ('python', 'cloudpickle', 'fsspec', 'numpy', 'partd', 'toolz')]


### PR DESCRIPTION
Space between operator and version was causing conda to fail with `Invalid spec: >=`.  Fixes AnacondaRecipes/dask-core-feedstock#3.

Resulting repodata.json diff:
```
--- a/main/noarch/reference_repodata.json
+++ b/main/noarch/repodata-patched.json
@@ -15743,7 +15743,7 @@
         "python >=3.7",
         "cloudpickle >=1.1.1",
         "fsspec >=0.6.0",
-        "partd >= 0.3.10",
+        "partd >=0.3.10",
         "pyyaml",
         "toolz >=0.8.2"
       ],
@@ -79198,7 +79198,7 @@
         "python >=3.7",
         "cloudpickle >=1.1.1",
         "fsspec >=0.6.0",
-        "partd >= 0.3.10",
+        "partd >=0.3.10",
         "pyyaml",
         "toolz >=0.8.2"
       ],
```