### PR TITLE
Fix gitpython 3.1.17 dependencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -877,6 +877,12 @@ def patch_record_in_place(fn, record, subdir):
         depends.append("numpy >=1.17.0,<2.0a0")
         depends.sort()
 
+    # some builds of gitpyhon 3.1.17 list the wrong dependencies
+    if name == "gitpython" and version == "3.1.17":
+        depends[:] = ["gitdb >=4.0.1,<5", "python >=3.5",
+                      "typing-extensions >=3.7.4.0"]
+
+
     ###########################
     # compilers and run times #
     ###########################


### PR DESCRIPTION
Repodata diff:
```
--- main/noarch/reference_repodata.json	2021-05-14 12:55:52.677460048 -0500
+++ main/noarch/repodata-patched.json	2021-05-14 12:56:05.221417236 -0500
@@ -24184,12 +24184,12 @@
     "gitpython-3.1.17-pyhd3eb1b0_1.tar.bz2": {
       "build": "pyhd3eb1b0_1",
       "build_number": 1,
       "depends": [
         "gitdb >=4.0.1,<5",
-        "python >=3.4",
-        "smmap >=3.0.1,<4"
+        "python >=3.5",
+        "typing-extensions >=3.7.4.0"
       ],
       "license": "BSD-3-Clause",
       "license_family": "BSD",
       "md5": "c57ad4b1450291c4db46dc08093ba138",
       "name": "gitpython",
@@ -89699,12 +89699,12 @@
     "gitpython-3.1.17-pyhd3eb1b0_1.conda": {
       "build": "pyhd3eb1b0_1",
       "build_number": 1,
       "depends": [
         "gitdb >=4.0.1,<5",
-        "python >=3.4",
-        "smmap >=3.0.1,<4"
+        "python >=3.5",
+        "typing-extensions >=3.7.4.0"
       ],
       "license": "BSD-3-Clause",
       "license_family": "BSD",
       "md5": "b8579b2223321bb707e4bb9c2c5c4a1e",
       "name": "gitpython",
```