### PR TITLE
Added patch to get click dependency version <8.0 for click-repl

### DIFF
--- a/main.py
+++ b/main.py
@@ -882,6 +882,10 @@ def patch_record_in_place(fn, record, subdir):
         depends[:] = ["gitdb >=4.0.1,<5", "python >=3.5",
                       "typing-extensions >=3.7.4.0"]
 
+    # click-repl incompatible with click >=8.0
+    if name == 'click-repl' and version == "0.1.6":
+        replace_dep(depends, 'click', 'click <8.0')
+
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -883,7 +883,8 @@ def patch_record_in_place(fn, record, subdir):
                       "typing-extensions >=3.7.4.0"]
 
     # click-repl incompatible with click >=8.0
-    if name == 'click-repl' and version == "0.1.6":
+    # TODO: set upper bounds once this is fixed upstream comment
+    if name == 'click-repl':
         replace_dep(depends, 'click', 'click <8.0')
 
 


### PR DESCRIPTION
Added patch to get click dependency version <8.0 for the package click-repl in main.py