### PR TITLE
Loosen zstd 1.4.x requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -715,13 +715,18 @@ def patch_record_in_place(fn, record, subdir):
     # kealib 1.4.8 changed sonames, add new upper bound to existing packages
     replace_dep(depends, 'kealib >=1.4.7,<1.5.0a0', 'kealib >=1.4.7,<1.4.8.0a0')
 
-    # zstd has been ABI compatible in the 1.4.x releases
-    replace_dep(depends, 'zstd >=1.4.4,<1.4.5.0a0', 'zstd >=1.4.4,<1.5.0a0')
-
-    # glib is compatible up to the major version
+    # Other broad replacements
     for i, dep in enumerate(depends):
+        # glib is compatible up to the major version
         if dep.startswith('glib >='):
             depends[i] = dep.split(',')[0] + ',<3.0a0'
+
+        # zstd has been more or less ABI compatible in the 1.4.x releases.
+        # `ZSTD_getSequences` is the only symbol reported as being removed
+        # between 1.4.0 and 1.5.0, but as far as we can tell, none of our
+        # (linux-64) packages actually use it.
+        if dep.startswith('zstd >=1.4.'):
+            depends[i] = dep.split(',')[0] + ',<1.5.0a0'
 
     # libffi broke ABI compatibility in 3.3
     if name not in LIBFFI_HOTFIX_EXCLUDES and \


### PR DESCRIPTION
See code comments for details; basically, extend the patch we already apply for zstd 1.4.4 to all of the zstd 1.4.x releases.
References: https://abi-laboratory.pro/index.php?view=timeline&l=zstd

Used `nm` + `grep` to check, and none of our linux-64 packages that depend on `zstd >=1.4.x` require the `ZSTD_getSequences` symbol [removed in zstd 1.4.7](https://abi-laboratory.pro/index.php?view=objects_report&l=zstd&v1=1.4.5&v2=1.4.7). Assuming the same applies for the other platforms.

Partial repodata.json diff:
```
--- main/linux-64/reference_repodata.json	2021-05-28 19:36:59.000000000 -0500
+++ main/linux-64/repodata-patched.json	2021-05-28 20:41:45.000000000 -0500
@@ -42070,15 +42070,15 @@
         "orc >=1.6.5,<1.6.6.0a0",
         "python >=3.6,<3.7.0a0",
         "re2",
         "snappy >=1.1.8,<2.0a0",
         "uriparser",
         "utf8proc",
         "zlib >=1.2.11,<1.3.0a0",
-        "zstd >=1.4.5,<1.4.6.0a0"
+        "zstd >=1.4.5,<1.5.0a0"
       ],
       "license": "Apache 2.0",
       "md5": "c5beebf262978a97b45b6495f8e44936",
       "name": "arrow-cpp",
       "sha256": "d89a15dbe676bfa06fb460b8cb9deb82b57a691166dfb53e16aba4eff565670e",
       "size": 7843155,
       "subdir": "linux-64",
@@ -60129,15 +60129,15 @@
       "build_number": 0,
       "depends": [
         "libgcc-ng >=7.3.0",
         "libstdcxx-ng >=7.3.0",
         "lz4-c >=1.9.2,<1.10.0a0",
         "snappy >=1.1.8,<2.0a0",
         "zlib >=1.2.11,<1.3.0a0",
-        "zstd >=1.4.5,<1.4.6.0a0"
+        "zstd >=1.4.5,<1.5.0a0"
       ],
       "license": "BSD-3-Clause",
       "md5": "af9779d64e59358b5a777cf55b62fddf",
       "name": "blosc",
       "sha256": "976d29f1aebb6556599d52b642adb78dc8c233983599c640a428e4271c87403e",
       "size": 83215,
       "subdir": "linux-64",
@@ -86068,15 +86068,15 @@
         "libgcc-ng >=7.3.0",
         "libstdcxx-ng >=7.3.0",
         "libuv >=1.39.0,<2.0a0",
         "ncurses >=6.2,<7.0a0",
         "rhash >=1.4.0,<2.0a0",
         "xz >=5.2.5,<6.0a0",
         "zlib >=1.2.11,<1.3.0a0",
-        "zstd >=1.4.5,<1.4.6.0a0"
+        "zstd >=1.4.5,<1.5.0a0"
       ],
       "license": "BSD 3-clause",
       "license_family": "BSD",
       "md5": "1603ec8880384435e15366dc92a38c77",
       "name": "cmake",
       "sha256": "60b5d9ac2431096fa0783c5be53147b214b4a983f152899332108fc9160f28b4",
       "size": 13934714,
@@ -173519,15 +173519,15 @@
         "lz4-c >=1.9.2,<1.10.0a0",
         "numpy >=1.15.4,<2.0a0",
         "openjpeg >=2.3.0,<3.0a0",
         "python >=3.6,<3.7.0a0",
         "snappy >=1.1.8,<2.0a0",
         "xz >=5.2.5,<6.0a0",
         "zlib >=1.2.11,<1.3.0a0",
-        "zstd >=1.4.5,<1.4.6.0a0"
+        "zstd >=1.4.5,<1.5.0a0"
       ],
       "license": "BSD-3-Clause",
       "license_family": "BSD",
       "md5": "b40de92b8be3f84bc6130049e6dc18cd",
       "name": "imagecodecs",
       "sha256": "9bc288fa38b3e32b097c2fdb6c3fe82ff0bd4001199e02e1759132b7469f1c0e",
       "size": 6354326,
@@ -203956,15 +203956,15 @@
       "depends": [
         "bzip2 >=1.0.8,<2.0a0",
         "icu >=58.2,<59.0a0",
         "libgcc-ng >=7.3.0",
         "libstdcxx-ng >=7.3.0",
         "xz >=5.2.5,<6.0a0",
         "zlib >=1.2.11,<1.3.0a0",
-        "zstd >=1.4.5,<1.4.6.0a0"
+        "zstd >=1.4.5,<1.5.0a0"
       ],
       "license": "Boost-1.0",
       "md5": "6e072917cdc1edbad2320bfaa9bea5ce",
       "name": "libboost",
       "sha256": "176d725e7d842857267548bbce703e5d0d59e5fd99c29ed4440686ece204f0c3",
       "size": 22283636,
       "subdir": "linux-64",
@@ -210054,15 +210054,15 @@
       "depends": [
         "jpeg >=9b,<10a",
         "libgcc-ng >=7.3.0",
         "libstdcxx-ng >=7.3.0",
         "libwebp-base",
         "xz >=5.2.5,<6.0a0",
         "zlib >=1.2.11,<1.3.0a0",
-        "zstd >=1.4.5,<1.4.6.0a0"
+        "zstd >=1.4.5,<1.5.0a0"
       ],
       "license": "HPND",
       "md5": "4a681051cf919b5a1ac2f128759769f0",
       "name": "libtiff",
       "sha256": "fea3847096b742bd5520f1969320737e1895d53e91513245c828dc827499692a",
       "size": 646802,
       "subdir": "linux-64",
@@ -276965,15 +276965,15 @@
       "depends": [
         "libgcc-ng >=7.3.0",
         "libprotobuf >=3.14.0,<3.15.0a0",
         "libstdcxx-ng >=7.3.0",
         "lz4-c >=1.9.2,<1.10.0a0",
         "snappy >=1.1.8,<2.0a0",
         "zlib >=1.2.11,<1.3.0a0",
-        "zstd >=1.4.5,<1.4.6.0a0"
+        "zstd >=1.4.5,<1.5.0a0"
       ],
       "license": "Apache-2.0",
       "license_family": "Apache",
       "md5": "e4a36c5fc36b7050226ae2752356380e",
       "name": "orc",
       "sha256": "b278dd2c97df551bec9b8d517339e21a0dfcf0ffb1351a389cd4d64aa9ae6021",
       "size": 705336,
```