### PR TITLE
Relax bounds on HDF5 1.10.x requirements

### DIFF
--- a/main.py
+++ b/main.py
@@ -728,6 +728,14 @@ def patch_record_in_place(fn, record, subdir):
         if dep.startswith('zstd >=1.4.'):
             depends[i] = dep.split(',')[0] + ',<1.5.0a0'
 
+        # hdf5 is ABI compatible between 1.10.3 to 1.10.7, inclusive.
+        # Ref: https://abi-laboratory.pro/index.php?view=timeline&l=hdf5
+        if dep.startswith('hdf5 >=1.10.'):
+            lower_bound = dep.split(',')[0]
+            patch_ver = lower_bound.split('.')[2]
+            if int(patch_ver) >= 3:
+                depends[i] = lower_bound + ',<1.10.8.0a0'
+
     # libffi broke ABI compatibility in 3.3
     if name not in LIBFFI_HOTFIX_EXCLUDES and \
             ('libffi >=3.2.1,<4.0a0' in depends or 'libffi' in depends):


### PR DESCRIPTION
Almost miraculously, HDF5 has remained ABI compatible between 1.10.4 to 1.10.7, inclusive (https://abi-laboratory.pro/index.php?view=timeline&l=hdf5). Update "depends" metadata for packages using those HDF5 versions to save ourselves a lot of rebuilding pain.

Partial diff from applying this patch:
```
--- main/linux-64/repodata-reference.json
+++ main/linux-64/repodata-patched.json
@@ -167340,19 +167340,19 @@
       "size": 1107971,
       "subdir": "linux-64",
       "timestamp": 1534896366448,
       "version": "2.8.0"
     },
     "h5py-2.9.0-py27h7918eee_0.tar.bz2": {
       "build": "py27h7918eee_0",
       "build_number": 0,
       "depends": [
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "libgcc-ng >=7.3.0",
         "numpy >=1.11.3,<2.0a0",
         "python >=2.7,<2.8.0a0",
         "six",
         "unittest2"
       ],
       "license": "BSD-3-Clause",
       "md5": "56143a9c47a786987cd55819fea7c0ef",
       "name": "h5py",
@@ -196554,19 +196554,19 @@
       "size": 244049,
       "subdir": "linux-64",
       "timestamp": 1593197090424,
       "version": "1.1"
     },
     "kealib-1.4.12-hd0c454d_0.tar.bz2": {
       "build": "hd0c454d_0",
       "build_number": 0,
       "depends": [
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "libgcc-ng >=7.3.0",
         "libstdcxx-ng >=7.3.0"
       ],
       "license": "MIT",
       "md5": "60803c2c5df9671fd19ddf0dcd676a34",
       "name": "kealib",
       "sha256": "5c6633c4acedfd9cdafccdc9c154775cd6cec29bb3983e3767552eb433df7dfc",
       "size": 179340,
       "subdir": "linux-64",
@@ -206341,19 +206341,19 @@
     "libgdal-2.3.3-h2e7e64b_0.tar.bz2": {
       "build": "h2e7e64b_0",
       "build_number": 0,
       "depends": [
         "expat >=2.2.6,<3.0a0",
         "freexl >=1.0.5,<2.0a0",
         "geos >=3.7.1,<3.7.2.0a0",
         "giflib >=5.1.4,<5.2.0a0",
         "hdf4 >=4.2.13,<4.2.14.0a0",
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "icu >=58.2,<59.0a0",
         "jpeg >=9b,<10a",
         "json-c >=0.13.1,<0.14.0a0",
         "kealib >=1.4.7,<1.4.8.0a0",
         "libcurl >=7.63.0,<8.0a0",
         "libdap4 >=3.19.1,<3.20.0a0",
         "libgcc-ng >=7.3.0",
         "libkml >=1.3.0,<1.4.0a0",
         "libnetcdf >=4.6.1,<4.7.0a0",
@@ -207697,19 +207697,19 @@
       "version": "4.6.1"
     },
     "libnetcdf-4.6.1-h11d0813_2.tar.bz2": {
       "build": "h11d0813_2",
       "build_number": 2,
       "depends": [
         "bzip2 >=1.0.6,<2.0a0",
         "curl",
         "hdf4 >=4.2.13,<4.2.14.0a0",
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "jpeg >=9b,<10a",
         "libcurl >=7.63.0,<8.0a0",
         "libgcc-ng >=7.3.0",
         "zlib >=1.2.11,<1.3.0a0"
       ],
       "license": "MIT",
       "md5": "ec2c16d46f789863c64709343226877d",
       "name": "libnetcdf",
       "sha256": "3c8aef66d0e261f32d5f998801a9aaa915325e8b11e8840df6f225080278f7bd",
@@ -238068,19 +238068,19 @@
       "subdir": "linux-64",
       "timestamp": 1541021514725,
       "version": "1.4.2"
     },
     "netcdf4-1.4.2-py27h808af73_0.tar.bz2": {
       "build": "py27h808af73_0",
       "build_number": 0,
       "depends": [
         "cftime",
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "libgcc-ng >=7.3.0",
         "libnetcdf >=4.6.1,<4.7.0a0",
         "numpy >=1.11.3,<2.0a0",
         "python >=2.7,<2.8.0a0",
         "setuptools"
       ],
       "license": "OSI Approved and MIT",
       "md5": "addf6d377cfb20d3e8308821a821d029",
       "name": "netcdf4",
@@ -326647,19 +326647,19 @@
       "timestamp": 1531093005190,
       "version": "1.5.0"
     },
     "pynio-1.5.0-py27hd2b2c5b_1.tar.bz2": {
       "build": "py27hd2b2c5b_1",
       "build_number": 1,
       "depends": [
         "g2clib >=1.6.0,<1.7.0a0",
         "hdf4 >=4.2.13,<4.2.14.0a0",
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "jasper >=2.0.14,<3.0a0",
         "libgcc-ng >=7.3.0",
         "libgdal >=2.3.3,<2.4.0a0",
         "libgfortran-ng >=7,<8.0a0",
         "libnetcdf >=4.6.1,<4.7.0a0",
         "libpng >=1.6.35,<1.7.0a0",
         "libstdcxx-ng >=7.3.0",
         "numpy >=1.11.3,<2.0a0",
         "proj4 >=5.2.0,<5.2.1.0a0",
@@ -334088,19 +334088,19 @@
       "timestamp": 1529061956406,
       "version": "3.4.4"
     },
     "pytables-3.4.4-py27h71ec239_0.tar.bz2": {
       "build": "py27h71ec239_0",
       "build_number": 0,
       "depends": [
         "blosc >=1.14.4,<2.0a0",
         "bzip2 >=1.0.6,<2.0a0",
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "libgcc-ng >=7.3.0",
         "libstdcxx-ng >=7.3.0",
         "lzo >=2.10,<3.0a0",
         "numexpr",
         "numpy >=1.11.3,<2.0a0",
         "python >=2.7,<2.8.0a0",
         "six",
         "zlib >=1.2.11,<1.3.0a0"
       ],
@@ -447020,19 +447020,19 @@
       "version": "8.1.1"
     },
     "vtk-8.2.0-py27haa4764d_200.tar.bz2": {
       "build": "py27haa4764d_200",
       "build_number": 200,
       "depends": [
         "expat >=2.2.6,<3.0a0",
         "freetype >=2.9.1,<3.0a0",
         "future",
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "jpeg >=9b,<10a",
         "jsoncpp",
         "libgcc-ng >=7.3.0",
         "libnetcdf >=4.6.1,<4.7.0a0",
         "libogg >=1.3.2,<2.0a0",
         "libpng >=1.6.36,<1.7.0a0",
         "libstdcxx-ng >=7.3.0",
         "libtheora >=1.1.1,<2.0a0",
         "libtiff >=4.0.10,<5.0a0",
@@ -457272,19 +457272,19 @@
       "subdir": "linux-64",
       "timestamp": 1520476514311,
       "version": "3.4.1"
     },
     "yt-3.4.1-py36h33eb3a4_2.tar.bz2": {
       "build": "py36h33eb3a4_2",
       "build_number": 2,
       "depends": [
         "h5py",
-        "hdf5 >=1.10.4,<1.10.5.0a0",
+        "hdf5 >=1.10.4,<1.10.8.0a0",
         "ipython",
         "libgcc-ng >=7.3.0",
         "matplotlib",
         "numpy >=1.11.3,<2.0a0",
         "python >=3.6,<3.7.0a0",
         "setuptools",
         "sympy"
       ],
       "license": "BSD 3-clause",
```