### PR TITLE
Revert "Relax bounds on HDF5 1.10.x requirements"

### DIFF
--- a/main.py
+++ b/main.py
@@ -728,14 +728,6 @@ def patch_record_in_place(fn, record, subdir):
         if dep.startswith('zstd >=1.4.'):
             depends[i] = dep.split(',')[0] + ',<1.5.0a0'
 
-        # hdf5 is ABI compatible between 1.10.3 to 1.10.7, inclusive.
-        # Ref: https://abi-laboratory.pro/index.php?view=timeline&l=hdf5
-        if dep.startswith('hdf5 >=1.10.'):
-            lower_bound = dep.split(',')[0]
-            patch_ver = lower_bound.split('.')[2]
-            if int(patch_ver) >= 3:
-                depends[i] = lower_bound + ',<1.10.8.0a0'
-
     # libffi broke ABI compatibility in 3.3
     if name not in LIBFFI_HOTFIX_EXCLUDES and \
             ('libffi >=3.2.1,<4.0a0' in depends or 'libffi' in depends):


### PR DESCRIPTION
Reverts AnacondaRecipes/repodata-hotfixes#121.

Users reporting issues like this:
```
Warning! ***HDF5 library version mismatched error***
The HDF5 header files used to compile this application do not match
the version used by the HDF5 library to which this application is linked.
Data corruption or segmentation faults may occur if the application continues.
This can happen when an application was compiled by one version of HDF5 but
linked with a different version of static or shared HDF5 library.
You should recompile the application or check your shared library related
settings such as 'LD_LIBRARY_PATH'.
You can, at your own risk, disable this warning by setting the environment
variable 'HDF5_DISABLE_VERSION_CHECK' to a value of '1'.
Setting it to 2 or higher will suppress the warning messages totally.
Headers are 1.10.6, library is 1.10.7
```