### PR TITLE
Fix distributed 2021.5.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -910,7 +910,7 @@ def patch_record_in_place(fn, record, subdir):
     # distributed 2021.5.0 requires dask-core >=2021.5.0
     # see how it was fixed for 2021.5.1 https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml
     if (name == 'distributed' and version == "2021.5.0" and build_number == 0):
-        replace_dep(depends, 'dask >=2021.04.0', 'dask-core 2021.5.0')
+        replace_dep(depends, 'dask >=2021.04.0', 'dask-core ==2021.5.0')
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -906,6 +906,11 @@ def patch_record_in_place(fn, record, subdir):
                     depends[i] = dep.split(',')[0] + ',<2.3'
                 if dep.startswith('bokeh >=1.'):
                     depends[i] = dep.split(',')[0] + ',<2.0.0a0'
+    
+    # distributed 2021.5.0 requires dask-core >=2021.5.0
+    # see how it was fixed for 2021.5.1 https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml
+    if (name == 'distributed' and version == "2021.5.0" and build_number == 0):
+        replace_dep(depends, 'dask >=2021.04.0', 'dask-core >=2021.5.0')
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -907,13 +907,14 @@ def patch_record_in_place(fn, record, subdir):
                 if dep.startswith('bokeh >=1.'):
                     depends[i] = dep.split(',')[0] + ',<2.0.0a0'
     
-    # distributed 2021.5.0 requires dask-core >=2021.5.0
-    # see how it was fixed for 2021.5.1 https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml
-    if (name == 'distributed' and version == "2021.5.0" and build_number == 0):
-        replace_dep(depends, 'dask >=2021.04.0', 'dask-core ==2021.5.0')
+    # distributed 2021.5.0 requires dask-core >=2021.5.0 and
     # distributed 2021.4.1 requires dask-core >=2021.4.1
-    if (name == 'distributed' and version == "2021.4.1" and build_number == 0):
-        replace_dep(depends, 'dask >=2021.3.0', 'dask-core ==2021.4.1')
+    # see how it was fixed for 2021.5.1 https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml
+    if name == 'distributed':
+        if version == "2021.5.0":
+            replace_dep(depends, 'dask >=2021.04.0', 'dask-core ==2021.5.0')
+        if version == "2021.4.1":
+            replace_dep(depends, 'dask >=2021.3.0', 'dask-core ==2021.4.1')
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -910,7 +910,7 @@ def patch_record_in_place(fn, record, subdir):
     # distributed 2021.5.0 requires dask-core >=2021.5.0
     # see how it was fixed for 2021.5.1 https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml
     if (name == 'distributed' and version == "2021.5.0" and build_number == 0):
-        replace_dep(depends, 'dask >=2021.04.0', 'dask-core >=2021.5.0')
+        replace_dep(depends, 'dask >=2021.04.0', 'dask-core 2021.5.0')
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -906,15 +906,15 @@ def patch_record_in_place(fn, record, subdir):
                     depends[i] = dep.split(',')[0] + ',<2.3'
                 if dep.startswith('bokeh >=1.'):
                     depends[i] = dep.split(',')[0] + ',<2.0.0a0'
-    
-    # distributed 2021.5.0 requires dask-core >=2021.5.0 and
-    # distributed 2021.4.1 requires dask-core >=2021.4.1
+
+    # distributed 2021.5.0 requires dask-core 2021.5.0 and
+    # distributed 2021.4.1 requires dask-core 2021.4.1
     # see how it was fixed for 2021.5.1 https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml
     if name == 'distributed':
         if version == "2021.5.0":
-            replace_dep(depends, 'dask >=2021.04.0', 'dask-core ==2021.5.0')
+            replace_dep(depends, 'dask >=2021.04.0', 'dask-core 2021.5.0.*')
         if version == "2021.4.1":
-            replace_dep(depends, 'dask >=2021.3.0', 'dask-core ==2021.4.1')
+            replace_dep(depends, 'dask >=2021.3.0', 'dask-core 2021.4.1.*')
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -911,6 +911,9 @@ def patch_record_in_place(fn, record, subdir):
     # see how it was fixed for 2021.5.1 https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml
     if (name == 'distributed' and version == "2021.5.0" and build_number == 0):
         replace_dep(depends, 'dask >=2021.04.0', 'dask-core ==2021.5.0')
+    # distributed 2021.4.1 requires dask-core >=2021.4.1
+    if (name == 'distributed' and version == "2021.4.1" and build_number == 0):
+        replace_dep(depends, 'dask >=2021.3.0', 'dask-core ==2021.4.1')
 
     ###########################
     # compilers and run times #


### PR DESCRIPTION
I've prepared fixes for **distributed 2021.5.0** and **distributed 2021.4.1**.
There was a wrong dependency inside meta.yaml files
Compare how it was fixed for the next and last version of distributed **2021.5.1** https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml 