### PR TITLE
Add typing-extensions dependency to gitpython=3.1.18

### DIFF
--- a/main.py
+++ b/main.py
@@ -883,7 +883,7 @@ def patch_record_in_place(fn, record, subdir):
         depends.sort()
 
     # some builds of gitpyhon 3.1.17 list the wrong dependencies
-    if name == "gitpython" and version == "3.1.17":
+    if name == "gitpython" and version in ("3.1.17", "3.1.18"):
         depends[:] = ["gitdb >=4.0.1,<5", "python >=3.5",
                       "typing-extensions >=3.7.4.0"]
 


### PR DESCRIPTION
Need to fix our recipe so this doesn't happen again. Output of `test-hotfix.py`:

```
--- main/noarch/repodata-reference.json
+++ main/noarch/repodata-patched.json
@@ -26912,11 +26912,12 @@
     "gitpython-3.1.18-pyhd3eb1b0_0.tar.bz2": {
       "build": "pyhd3eb1b0_0",
       "build_number": 0,
       "depends": [
         "gitdb >=4.0.1,<5",
-        "python >=3.5"
+        "python >=3.5",
+        "typing-extensions >=3.7.4.0"
       ],
       "license": "BSD-3-Clause",
       "license_family": "BSD",
       "md5": "f835aeea5611ba5125dd0b0a378176a6",
       "name": "gitpython",
@@ -100627,11 +100628,12 @@
     "gitpython-3.1.18-pyhd3eb1b0_0.conda": {
       "build": "pyhd3eb1b0_0",
       "build_number": 0,
       "depends": [
         "gitdb >=4.0.1,<5",
-        "python >=3.5"
+        "python >=3.5",
+        "typing-extensions >=3.7.4.0"
       ],
       "license": "BSD-3-Clause",
       "license_family": "BSD",
       "md5": "bfd5032cde4a5db647897abb2250fc0c",
       "name": "gitpython",
```