### PR TITLE
Ensure that r package metadata has 'subdir' fields

### DIFF
--- a/r.py
+++ b/r.py
@@ -203,6 +203,11 @@ def _patch_repodata(repodata, subdir):
                 record['depends'].append('r-base 3.1.2')
                 instructions["packages"][fn]["depends"] = record['depends']
 
+        # Every artifact's metadata requires 'subdir'.
+        if "subdir" not in record:
+            record["subdir"] = subdir
+            instructions["packages"][fn]["subdir"] = subdir
+
         # cyclical dep here.  Everything should depend on r-base instead of r, as r brings in r-essentials
         new_deps = []
         for dep in record['depends']:


### PR DESCRIPTION
Ensure that r package metadata has 'subdir' fields by updating the hotfixes specified in r.py to check.

Please note that like many of the patching instructions, this does not change repodata about .conda packages (which is kept in the "packages.conda" dict in repodata.)

This tested successfully on a local repository and then on the actual build network.

In the future, a cleaner structure around required fields would be beneficial.