### PR TITLE
Add `__glibc` depends to newer GCC runtime libraries

### DIFF
--- a/main.py
+++ b/main.py
@@ -943,6 +943,17 @@ def patch_record_in_place(fn, record, subdir):
     if name == 'libgcc-ng':
         depends.append('_libgcc_mutex * main')
 
+    # Limit breaks as we transition from CentOS 6 to 7
+    if (subdir == 'linux-64' and
+            name in ('libgcc-ng', 'libstdcxx-ng', 'libgfortran-ng') and
+            version in ('7.5.0', '8.4.0', '9.3.0')
+            ):
+        # This would probably be better as a `constrains`, but conda's solver
+        # currently has issues enforcing virtual package constrains. Making
+        # `__glibc` a hard `depends` will almost surely break building
+        # cross-platform environments (e.g., via setting `$CONDA_SUBDIR`).
+        depends.append('__glibc >=2.17')
+
     if subdir == "osx-64":
         # fix clang_osx-64 and clangcxx_osx-64 packages to include dependencies, see:
         # https://github.com/AnacondaRecipes/aggregate/pull/164


### PR DESCRIPTION
Newer versions of GCC runtime libraries (`lib*-ng`) were built using CentOS 7 as a target; adding the `__glibc` depends prevents the conda solver from considering these newer releases on older systems (e.g., CentOS 6) and breaking conda environments. Adding these depends to the GCC runtime libraries has the added benefit of basically eliminating the need to add similar constraints to packages built using newer compilers.

Fixes AnacondaRecipes/repodata-hotfixes#126

Proposed repodata.json changes:
```
--- main/linux-64/repodata-reference.json	2021-07-01 10:56:07.350589280 -0500
+++ main/linux-64/repodata-patched.json	2021-07-01 10:57:08.768270856 -0500
@@ -208207,15 +208207,16 @@
       "build_number": 17,
       "constrains": [
         "libgomp 7.5.0 h5101ec6_17"
       ],
       "depends": [
         "_libgcc_mutex 0.1 main",
         "_openmp_mutex >=4.5",
-        "_libgcc_mutex * main"
+        "_libgcc_mutex * main",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "bf9a7b4b875ac4873a8be537822b8b03",
       "name": "libgcc-ng",
       "sha256": "e9a120e8ff26442e6a42b77a585a5dff98e404403261839080b55685fef34221",
       "size": 6198919,
       "subdir": "linux-64",
@@ -208257,15 +208258,16 @@
       "build_number": 17,
       "constrains": [
         "libgomp 8.4.0 h5101ec6_17"
       ],
       "depends": [
         "_libgcc_mutex 0.1 main",
         "_openmp_mutex >=4.5",
-        "_libgcc_mutex * main"
+        "_libgcc_mutex * main",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "4e2b806b170198fd3af8d22a610b7cd9",
       "name": "libgcc-ng",
       "sha256": "403cac2852365ca509c19cc9ddc3c6ea0330ef055449f86c4064d982c645de59",
       "size": 7719830,
       "subdir": "linux-64",
@@ -208292,15 +208294,16 @@
       "build_number": 17,
       "constrains": [
         "libgomp 9.3.0 h5101ec6_17"
       ],
       "depends": [
         "_libgcc_mutex 0.1 main",
         "_openmp_mutex >=4.5",
-        "_libgcc_mutex * main"
+        "_libgcc_mutex * main",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "877cdee0cc95b9b1a685a2d047072364",
       "name": "libgcc-ng",
       "sha256": "bdb43a7a4483ab03f4d5dba6212d5d9462764980c01cdea524eebc156765f540",
       "size": 8201947,
       "subdir": "linux-64",
@@ -209216,15 +209219,16 @@
       "timestamp": 1534628456385,
       "version": "7.3.0"
     },
     "libgfortran-ng-7.5.0-ha8ba4b0_17.tar.bz2": {
       "build": "ha8ba4b0_17",
       "build_number": 17,
       "depends": [
-        "libgfortran4 7.5.0.*"
+        "libgfortran4 7.5.0.*",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "526a52415a29fc6df26612f2d42b162f",
       "name": "libgfortran-ng",
       "sha256": "baf06cda3054e2a1eb67b2dfb28fb11b6245f6c1625f369a7629dfcee622e96f",
       "size": 22250,
       "subdir": "linux-64",
@@ -209257,30 +209261,32 @@
       "timestamp": 1534516119090,
       "version": "8.2.0"
     },
     "libgfortran-ng-8.4.0-he6ba991_17.tar.bz2": {
       "build": "he6ba991_17",
       "build_number": 17,
       "depends": [
-        "libgfortran5 8.4.0.*"
+        "libgfortran5 8.4.0.*",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "dedce0103828ebcc479ce1b80f6404cf",
       "name": "libgfortran-ng",
       "sha256": "b8cec01ebc8212cd827647acc0461c1fa71041ed5e55853e5da759d30e434b8e",
       "size": 22268,
       "subdir": "linux-64",
       "timestamp": 1622661689809,
       "version": "8.4.0"
     },
     "libgfortran-ng-9.3.0-ha5ec8a7_17.tar.bz2": {
       "build": "ha5ec8a7_17",
       "build_number": 17,
       "depends": [
-        "libgfortran5 9.3.0.*"
+        "libgfortran5 9.3.0.*",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "7cf9711f0474ff216fe8deb9ebe061e1",
       "name": "libgfortran-ng",
       "sha256": "ec57e194d98ee57c161e54056e323e5d8e2070749b11d64d2eec34c4700dc772",
       "size": 22258,
       "subdir": "linux-64",
@@ -212758,15 +212764,17 @@
       "subdir": "linux-64",
       "timestamp": 1534628462259,
       "version": "7.3.0"
     },
     "libstdcxx-ng-7.5.0-hd4cf53a_17.tar.bz2": {
       "build": "hd4cf53a_17",
       "build_number": 17,
-      "depends": [],
+      "depends": [
+        "__glibc >=2.17"
+      ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "d13c7bc86530d1d695eeb80612d0c251",
       "name": "libstdcxx-ng",
       "sha256": "00c010a27abb4f60f5c8aff4d559fb7dbec1b4a2535dd9a9355ffdc6547993f8",
       "size": 2700180,
       "subdir": "linux-64",
       "timestamp": 1622660076260,
@@ -212797,15 +212805,17 @@
       "subdir": "linux-64",
       "timestamp": 1534516131602,
       "version": "8.2.0"
     },
     "libstdcxx-ng-8.4.0-hd4cf53a_17.tar.bz2": {
       "build": "hd4cf53a_17",
       "build_number": 17,
-      "depends": [],
+      "depends": [
+        "__glibc >=2.17"
+      ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "a0eb1fbf08466611a01e1fdaceab4302",
       "name": "libstdcxx-ng",
       "sha256": "b7ee496145437c9bb6ed6923fb7c7f5a6957c4add38365918bdcef5b395422c7",
       "size": 3064749,
       "subdir": "linux-64",
       "timestamp": 1622661686810,
@@ -212823,15 +212833,17 @@
       "subdir": "linux-64",
       "timestamp": 1560112223556,
       "version": "9.1.0"
     },
     "libstdcxx-ng-9.3.0-hd4cf53a_17.tar.bz2": {
       "build": "hd4cf53a_17",
       "build_number": 17,
-      "depends": [],
+      "depends": [
+        "__glibc >=2.17"
+      ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "47415cfbf9f3d288981db1cd97cfe97b",
       "name": "libstdcxx-ng",
       "sha256": "564810f222aaac1d23bf5265f9a63f62e18f504a38aa33d418e628c1b6ea9fb5",
       "size": 4235389,
       "subdir": "linux-64",
       "timestamp": 1622663335295,
@@ -673249,15 +673261,16 @@
       "build_number": 17,
       "constrains": [
         "libgomp 7.5.0 h5101ec6_17"
       ],
       "depends": [
         "_libgcc_mutex 0.1 main",
         "_openmp_mutex >=4.5",
-        "_libgcc_mutex * main"
+        "_libgcc_mutex * main",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "b387c3f062fd3f8c366258d56c89273f",
       "name": "libgcc-ng",
       "sha256": "154e431b52e6ed1de2abfb79d233fe58ea1a33223340767de5c8829fceb94ef3",
       "size": 3837112,
       "subdir": "linux-64",
@@ -673299,15 +673312,16 @@
       "build_number": 17,
       "constrains": [
         "libgomp 8.4.0 h5101ec6_17"
       ],
       "depends": [
         "_libgcc_mutex 0.1 main",
         "_openmp_mutex >=4.5",
-        "_libgcc_mutex * main"
+        "_libgcc_mutex * main",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "669ef30dadfcc92d455367c32682a42e",
       "name": "libgcc-ng",
       "sha256": "2b93adf85134046d80a707fcbb3bd287c5c44a94501c2455200846a62aa3e5ad",
       "size": 4756676,
       "subdir": "linux-64",
@@ -673334,15 +673348,16 @@
       "build_number": 17,
       "constrains": [
         "libgomp 9.3.0 h5101ec6_17"
       ],
       "depends": [
         "_libgcc_mutex 0.1 main",
         "_openmp_mutex >=4.5",
-        "_libgcc_mutex * main"
+        "_libgcc_mutex * main",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "e9cbabbfb9e8a430f6a7660fe8dd77a7",
       "name": "libgcc-ng",
       "sha256": "49a808720a51c107241a42ac3641cce3d8451ef7cfaf3d68b6e4a3fec2da0676",
       "size": 5035441,
       "subdir": "linux-64",
@@ -674258,15 +674273,16 @@
       "timestamp": 1534628456385,
       "version": "7.3.0"
     },
     "libgfortran-ng-7.5.0-ha8ba4b0_17.conda": {
       "build": "ha8ba4b0_17",
       "build_number": 17,
       "depends": [
-        "libgfortran4 7.5.0.*"
+        "libgfortran4 7.5.0.*",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "ecb35c8952579d5c8dc56c6e076ba948",
       "name": "libgfortran-ng",
       "sha256": "f962258281d978f7b0e8207304531a60860c2e54cf2f2e59ae380d22fe10f1d2",
       "size": 22460,
       "subdir": "linux-64",
@@ -674299,30 +674315,32 @@
       "timestamp": 1534516119090,
       "version": "8.2.0"
     },
     "libgfortran-ng-8.4.0-he6ba991_17.conda": {
       "build": "he6ba991_17",
       "build_number": 17,
       "depends": [
-        "libgfortran5 8.4.0.*"
+        "libgfortran5 8.4.0.*",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "72dc32f8df8e8898f740a65a0aa1de6e",
       "name": "libgfortran-ng",
       "sha256": "fbae230e8356aafa82ac1f33d880395474e8275a93f29c140bfe18edb0591638",
       "size": 22447,
       "subdir": "linux-64",
       "timestamp": 1622661689809,
       "version": "8.4.0"
     },
     "libgfortran-ng-9.3.0-ha5ec8a7_17.conda": {
       "build": "ha5ec8a7_17",
       "build_number": 17,
       "depends": [
-        "libgfortran5 9.3.0.*"
+        "libgfortran5 9.3.0.*",
+        "__glibc >=2.17"
       ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "1e6b98f15e9ff3a0a54b8256500cc4e1",
       "name": "libgfortran-ng",
       "sha256": "d3f33865f55a3adbf61b74f2e8b38e37fd4e03752ef831ab8ed822992149aebe",
       "size": 22431,
       "subdir": "linux-64",
@@ -677800,15 +677818,17 @@
       "subdir": "linux-64",
       "timestamp": 1534628462259,
       "version": "7.3.0"
     },
     "libstdcxx-ng-7.5.0-hd4cf53a_17.conda": {
       "build": "hd4cf53a_17",
       "build_number": 17,
-      "depends": [],
+      "depends": [
+        "__glibc >=2.17"
+      ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "2f479f358916ea446bc54dbf49d08374",
       "name": "libstdcxx-ng",
       "sha256": "30704098949813551333da01dc66933b123e6f2d5b9fc9b01e14d97f990c5ad0",
       "size": 2049419,
       "subdir": "linux-64",
       "timestamp": 1622660076260,
@@ -677839,15 +677859,17 @@
       "subdir": "linux-64",
       "timestamp": 1534516131602,
       "version": "8.2.0"
     },
     "libstdcxx-ng-8.4.0-hd4cf53a_17.conda": {
       "build": "hd4cf53a_17",
       "build_number": 17,
-      "depends": [],
+      "depends": [
+        "__glibc >=2.17"
+      ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "7741dea5b4846da471b1ab3d9cdfcb44",
       "name": "libstdcxx-ng",
       "sha256": "64388e7e5c028ce52ac2f6c936a7661ee5bf21c65032d9ba279afc08f73428cf",
       "size": 2356019,
       "subdir": "linux-64",
       "timestamp": 1622661686810,
@@ -677865,15 +677887,17 @@
       "subdir": "linux-64",
       "timestamp": 1560112223556,
       "version": "9.1.0"
     },
     "libstdcxx-ng-9.3.0-hd4cf53a_17.conda": {
       "build": "hd4cf53a_17",
       "build_number": 17,
-      "depends": [],
+      "depends": [
+        "__glibc >=2.17"
+      ],
       "license": "GPL-3.0-only WITH GCC-exception-3.1",
       "md5": "47744aca0f5e63c4672d117c3596d937",
       "name": "libstdcxx-ng",
       "sha256": "0cdad3721336fe93f626289dd45e864eb4a0659ff2094670af01e7eacad28d9c",
       "size": 3248965,
       "subdir": "linux-64",
       "timestamp": 1622663335295,
```