### PR TITLE
Add lint step with flake8 and problem matcher to github action

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 120

--- a/.github/flake8-matcher.json
+++ b/.github/flake8-matcher.json
@@ -1,0 +1,17 @@
+{
+  "problemMatcher": [
+    {
+      "owner": "flake8",
+      "pattern": [
+        {
+          "regexp": "^([^:]*):(\\d+):(\\d+): (\\w+\\d\\d\\d) (.*)$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "code": 4,
+          "message": 5
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,14 @@ jobs:
       - name: Setup environment
         shell: bash -l {0}
         run: |
-          conda create --name testenv conda conda-build requests
+          conda create --name testenv conda conda-build flake8 requests
+      - name: Lint
+        shell: bash -l {0}
+        run: |
+          conda activate testenv
+          echo "::add-matcher::.github/flake8-matcher.json"
+          flake8 --count --exit-zero .
+          echo "::remove-matcher owner=flake8::"
       - name: Test
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Linting findings do not block CI, but they are visualised via problem matcher in the PR diff.