### PR TITLE
Fix depends for distributed=2021.4.1

### DIFF
--- a/main.py
+++ b/main.py
@@ -906,15 +906,15 @@ def patch_record_in_place(fn, record, subdir):
                 if dep.startswith('bokeh >=1.'):
                     depends[i] = dep.split(',')[0] + ',<2.0.0a0'
 
-    # distributed 2021.5.0 requires dask-core 2021.5.0 and
-    # distributed 2021.4.1 requires dask-core 2021.4.1
+    # distributed requires `dask-core`, not `dask`. This requirement also
+    # became much stricter with the upstream 2021.5.0 release.
     # see how it was fixed for 2021.5.1:
     #   https://github.com/AnacondaRecipes/distributed-feedstock/blob/master/recipe/meta.yaml
     if name == 'distributed':
         if version == "2021.5.0":
             replace_dep(depends, 'dask >=2021.04.0', 'dask-core 2021.5.0.*')
         if version == "2021.4.1":
-            replace_dep(depends, 'dask >=2021.3.0', 'dask-core 2021.4.1.*')
+            replace_dep(depends, 'dask >=2021.3.0', 'dask-core >=2021.3.0')
 
     # aiobotocore 1.2.2 needs botocore >=1.19.52,<1.19.53
     if name == 'aiobotocore' and version.startswith('1.2.'):


### PR DESCRIPTION
Loosen `dask-core` requirement to match upstream specifications; this also resolves a dependency conflict that prevented the `anaconda=2021.05` meta-package from being installed.