### PR TITLE
Fix `cryptography` depends/contraints for pyjwt=2.1.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -925,6 +925,11 @@ def patch_record_in_place(fn, record, subdir):
     if name == 'aiobotocore' and version.startswith('1.2.'):
         replace_dep(depends, 'botocore', 'botocore >=1.19.52,<1.19.53')
 
+    # pyjwt 2.1.0 has incorrect depends/constrains on cryptography
+    if name == 'pyjwt' and version == '2.1.0':
+        depends[:] = list(d for d in depends if not d.startswith('cryptography '))
+        record["constrains"] = ['cryptography >=3.3.1,<4.0.0']
+
     ###########################
     # compilers and run times #
     ###########################


### PR DESCRIPTION
`pyjwt` 2.1.0 packages for Python <3.9 have incorrectly specified run dependencies on `cryptography`; this repodata patch addresses that issue. Note that the feedstock seems to be correct.

Partial diff of this patch (linux-64 shown here, but similar results for all platforms):
```
 --- main/linux-64/repodata-reference.json
+++ main/linux-64/repodata-patched.json
@@ -327375,12 +327375,14 @@
       "version": "2.0.1"
     },
     "pyjwt-2.1.0-py36h06a4308_0.tar.bz2": {
       "build": "py36h06a4308_0",
       "build_number": 0,
+      "constrains": [
+        "cryptography >=3.3.1,<4.0.0"
+      ],
       "depends": [
-        "cryptography >=2.6,<3.0.0",
         "python >=3.6,<3.7.0a0"
       ],
       "license": "MIT",
       "license_family": "MIT",
       "md5": "b0551c9f70d9de0ef12f89df8bce0258",
@@ -327392,12 +327394,14 @@
       "version": "2.1.0"
     },
     "pyjwt-2.1.0-py37h06a4308_0.tar.bz2": {
       "build": "py37h06a4308_0",
       "build_number": 0,
+      "constrains": [
+        "cryptography >=3.3.1,<4.0.0"
+      ],
       "depends": [
-        "cryptography >=2.6,<3.0.0",
         "python >=3.7,<3.8.0a0"
       ],
       "license": "MIT",
       "license_family": "MIT",
       "md5": "ce6980cc7ff52063750c682f2fcc3a80",
@@ -327409,12 +327413,14 @@
       "version": "2.1.0"
     },
     "pyjwt-2.1.0-py38h06a4308_0.tar.bz2": {
       "build": "py38h06a4308_0",
       "build_number": 0,
+      "constrains": [
+        "cryptography >=3.3.1,<4.0.0"
+      ],
       "depends": [
-        "cryptography >=2.6,<3.0.0",
         "python >=3.8,<3.9.0a0"
       ],
       "license": "MIT",
       "license_family": "MIT",
       "md5": "4eb0567ef65a9a649be8b40354d0e498",
```