### PR TITLE
Updated numpy version for pyerfa 2.0.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -930,6 +930,9 @@ def patch_record_in_place(fn, record, subdir):
         depends[:] = list(d for d in depends if not d.startswith('cryptography '))
         record["constrains"] = ['cryptography >=3.3.1,<4.0.0']
 
+    if name == 'pyerfa' and version == '2.0.0':
+        replace_dep(depends, 'numpy >=1.17', 'numpy >=1.20.2,<2.0a0')
+
     ###########################
     # compilers and run times #
     ###########################


### PR DESCRIPTION
1.Updated numpy version from >=1.17 to >=1.20.2,<2.0a0. for pyerfa 2.0.0


This is a fix for https://github.com/AnacondaRecipes/repodata-hotfixes/issues/123