### PR TITLE
pandas 1.3.0: remove run constrains; fix Py3.7 depends spec

### DIFF
--- a/main.py
+++ b/main.py
@@ -933,6 +933,17 @@ def patch_record_in_place(fn, record, subdir):
     if name == 'pyerfa' and version == '2.0.0':
         replace_dep(depends, 'numpy >=1.17', 'numpy >=1.20.2,<2.0a0')
 
+    # Possible bug in conda solver, wherein run constrains seem to completely
+    # override version requirements in `depends`.  This results in users being
+    # able to (e.g.) install the Py3.9 build in Py3.7 or Py3.8 environments.
+    if name == 'pandas' and version == '1.3.0':
+        constrains.clear()
+        # Still to set lower bound on compatible Py3.7 interpreters
+        if record['build'].startswith('py37'):
+            for i, dep in enumerate(depends):
+                if dep.startswith('python '):
+                    depends[i] = "python >=3.7.1,<3.8.0a0"
+
     ###########################
     # compilers and run times #
     ###########################


### PR DESCRIPTION
Our updated recipe used a run constrains to enforce a minimum version of Python 3.7; however, due to a bug(?) and/or non-intuitive behavior in the conda solver, having a run constrain seems to completely override any version requirements specified in the `depends` section for the corresponding package. This repodata patch removes the run constrains and just patches the minimum version for the Py3.7 build.

Fixes pandas-dev/pandas#42627

Partial result from this patch:
```
--- main/linux-64/repodata-reference.json
+++ main/linux-64/repodata-patched.json
@@ -285716,20 +285716,18 @@
       "version": "1.2.5"
     },
     "pandas-1.3.0-py37h295c915_0.tar.bz2": {
       "build": "py37h295c915_0",
       "build_number": 0,
-      "constrains": [
-        "python !=3.7.0"
-      ],
+      "constrains": [],
       "depends": [
         "bottleneck >=1.2.1",
         "libgcc-ng >=7.5.0",
         "libstdcxx-ng >=7.5.0",
         "numexpr >=2.7.0",
         "numpy >=1.20.3,<2.0a0",
-        "python >=3.7,<3.8.0a0",
+        "python >=3.7.1,<3.8.0a0",
         "python-dateutil >=2.7.3",
         "pytz >=2017.3"
       ],
       "license": "BSD-3-Clause",
       "license_family": "BSD",
@@ -285742,13 +285740,11 @@
       "version": "1.3.0"
     },
     "pandas-1.3.0-py38h295c915_0.tar.bz2": {
       "build": "py38h295c915_0",
       "build_number": 0,
-      "constrains": [
-        "python !=3.7.0"
-      ],
+      "constrains": [],
       "depends": [
         "bottleneck >=1.2.1",
         "libgcc-ng >=7.5.0",
         "libstdcxx-ng >=7.5.0",
         "numexpr >=2.7.0",
@@ -285768,13 +285764,11 @@
       "version": "1.3.0"
     },
     "pandas-1.3.0-py39h295c915_0.tar.bz2": {
       "build": "py39h295c915_0",
       "build_number": 0,
-      "constrains": [
-        "python !=3.7.0"
-      ],
+      "constrains": [],
       "depends": [
         "bottleneck >=1.2.1",
         "libgcc-ng >=7.5.0",
         "libstdcxx-ng >=7.5.0",
         "numexpr >=2.7.0",
@@ -754824,20 +754818,18 @@
       "version": "1.2.5"
     },
     "pandas-1.3.0-py37h295c915_0.conda": {
       "build": "py37h295c915_0",
       "build_number": 0,
-      "constrains": [
-        "python !=3.7.0"
-      ],
+      "constrains": [],
       "depends": [
         "bottleneck >=1.2.1",
         "libgcc-ng >=7.5.0",
         "libstdcxx-ng >=7.5.0",
         "numexpr >=2.7.0",
         "numpy >=1.20.3,<2.0a0",
-        "python >=3.7,<3.8.0a0",
+        "python >=3.7.1,<3.8.0a0",
         "python-dateutil >=2.7.3",
         "pytz >=2017.3"
       ],
       "license": "BSD-3-Clause",
       "license_family": "BSD",
@@ -754850,13 +754842,11 @@
       "version": "1.3.0"
     },
     "pandas-1.3.0-py38h295c915_0.conda": {
       "build": "py38h295c915_0",
       "build_number": 0,
-      "constrains": [
-        "python !=3.7.0"
-      ],
+      "constrains": [],
       "depends": [
         "bottleneck >=1.2.1",
         "libgcc-ng >=7.5.0",
         "libstdcxx-ng >=7.5.0",
         "numexpr >=2.7.0",
@@ -754876,13 +754866,11 @@
       "version": "1.3.0"
     },
     "pandas-1.3.0-py39h295c915_0.conda": {
       "build": "py39h295c915_0",
       "build_number": 0,
-      "constrains": [
-        "python !=3.7.0"
-      ],
+      "constrains": [],
       "depends": [
         "bottleneck >=1.2.1",
         "libgcc-ng >=7.5.0",
         "libstdcxx-ng >=7.5.0",
         "numexpr >=2.7.0",
```