### PR TITLE
"Remove" cffi 1.14.6 packages with broken run depends

### DIFF
--- a/main.py
+++ b/main.py
@@ -27,10 +27,25 @@ SUBDIRS = (
 
 REMOVALS = {
     "noarch": (),
-    "linux-ppc64le": [],
+    "linux-ppc64le": [
+        # This build contains incorrect libffi run depends; removing rather
+        # than patching to prevent solver from getting stuck in a bistable
+        # solution (since another build has the same set of requirements).
+        "cffi-1.14.6-py36h140841e_0.tar.bz2",
+        "cffi-1.14.6-py37h140841e_0.tar.bz2",
+        "cffi-1.14.6-py38h140841e_0.tar.bz2",
+        "cffi-1.14.6-py39h140841e_0.tar.bz2",
+        ],
     "osx-64": [
         # qt 5.9.7 accidentially added .conda. to the dylibs names
         'qt-5.9.7-h468cd18_0.tar.bz2',
+        # This build contains incorrect libffi run depends; removing rather
+        # than patching to prevent solver from getting stuck in a bistable
+        # solution (since another build has the same set of requirements).
+        "cffi-1.14.6-py36h9ed2024_0.tar.bz2",
+        "cffi-1.14.6-py37h9ed2024_0.tar.bz2",
+        "cffi-1.14.6-py38h9ed2024_0.tar.bz2",
+        "cffi-1.14.6-py39h9ed2024_0.tar.bz2",
         ],
     "win-32": ["nomkl-*"],
     "win-64": [
@@ -40,6 +55,13 @@ REMOVALS = {
     ],
     "linux-64": [
         "numba-0.46.0-py38h962f231_0.tar.bz2",
+        # This build contains incorrect libffi run depends; removing rather
+        # than patching to prevent solver from getting stuck in a bistable
+        # solution (since another build has the same set of requirements).
+        "cffi-1.14.6-py36h7f8727e_0.tar.bz2",
+        "cffi-1.14.6-py37h7f8727e_0.tar.bz2",
+        "cffi-1.14.6-py38h7f8727e_0.tar.bz2",
+        "cffi-1.14.6-py39h7f8727e_0.tar.bz2",
     ],
     "any": {
         # early efforts on splitting numpy recipe did not pin numpy-base exactly.


### PR DESCRIPTION
Resulting changes:
```
--- main/linux-64/reference_repodata.json	2021-07-28 14:55:03.000000000 -0500
+++ main/linux-64/repodata-patched.json	2021-07-28 14:55:30.000000000 -0500
@@ -77954,25 +77954,6 @@
       "timestamp": 1625814764180,
       "version": "1.14.6"
     },
-    "cffi-1.14.6-py36h7f8727e_0.tar.bz2": {
-      "build": "py36h7f8727e_0",
-      "build_number": 0,
-      "depends": [
-        "libffi >=3.2.1,<3.3a0",
-        "libgcc-ng >=7.5.0",
-        "pycparser >=2.06",
-        "python >=3.6,<3.7.0a0"
-      ],
-      "license": "MIT",
-      "license_family": "MIT",
-      "md5": "f868026cac8288e56fa44bb08615f1de",
-      "name": "cffi",
-      "sha256": "a7a7186e027822416d33606ed44673161783b36e0788b2e458d6a47453752040",
-      "size": 228871,
-      "subdir": "linux-64",
-      "timestamp": 1625831738731,
-      "version": "1.14.6"
-    },
     "cffi-1.14.6-py37h400218f_0.tar.bz2": {
       "build": "py37h400218f_0",
       "build_number": 0,
@@ -77991,25 +77972,6 @@
       "timestamp": 1625814747956,
       "version": "1.14.6"
     },
-    "cffi-1.14.6-py37h7f8727e_0.tar.bz2": {
-      "build": "py37h7f8727e_0",
-      "build_number": 0,
-      "depends": [
-        "libffi >=3.2.1,<3.3a0",
-        "libgcc-ng >=7.5.0",
-        "pycparser >=2.06",
-        "python >=3.7,<3.8.0a0"
-      ],
-      "license": "MIT",
-      "license_family": "MIT",
-      "md5": "852fa630fc9dc75e9fd0d6751e48690e",
-      "name": "cffi",
-      "sha256": "2446b8376930eb12ee8bb5af922770ad23b054916c4c50e0dfbc4cd543b2d328",
-      "size": 229266,
-      "subdir": "linux-64",
-      "timestamp": 1625831722937,
-      "version": "1.14.6"
-    },
     "cffi-1.14.6-py38h400218f_0.tar.bz2": {
       "build": "py38h400218f_0",
       "build_number": 0,
@@ -78028,25 +77990,6 @@
       "timestamp": 1625807894199,
       "version": "1.14.6"
     },
-    "cffi-1.14.6-py38h7f8727e_0.tar.bz2": {
-      "build": "py38h7f8727e_0",
-      "build_number": 0,
-      "depends": [
-        "libffi >=3.2.1,<3.3a0",
-        "libgcc-ng >=7.5.0",
-        "pycparser >=2.06",
-        "python >=3.8,<3.9.0a0"
-      ],
-      "license": "MIT",
-      "license_family": "MIT",
-      "md5": "f67bde30fda1f2b9166f59ec3ae26940",
-      "name": "cffi",
-      "sha256": "7d5790396e050c4d6948ab5c72c0e30b91c26d274b89f058b428f1e926392638",
-      "size": 231199,
-      "subdir": "linux-64",
-      "timestamp": 1625831305203,
-      "version": "1.14.6"
-    },
     "cffi-1.14.6-py39h400218f_0.tar.bz2": {
       "build": "py39h400218f_0",
       "build_number": 0,
@@ -78065,25 +78008,6 @@
       "timestamp": 1625814763237,
       "version": "1.14.6"
     },
-    "cffi-1.14.6-py39h7f8727e_0.tar.bz2": {
-      "build": "py39h7f8727e_0",
-      "build_number": 0,
-      "depends": [
-        "libffi >=3.2.1,<3.3a0",
-        "libgcc-ng >=7.5.0",
-        "pycparser >=2.06",
-        "python >=3.9,<3.10.0a0"
-      ],
-      "license": "MIT",
-      "license_family": "MIT",
-      "md5": "9c4e415e83004c719702c61209c4d16e",
-      "name": "cffi",
-      "sha256": "7f90aab5283970e3bb117f99719e40350fa8c26e23f211dc72f1f4d9bf3a4390",
-      "size": 231863,
-      "subdir": "linux-64",
-      "timestamp": 1625831731434,
-      "version": "1.14.6"
-    },
     "cfitsio-3.470-hb7c8383_2.tar.bz2": {
       "build": "hb7c8383_2",
       "build_number": 2,
@@ -549759,25 +549683,6 @@
       "timestamp": 1625814764180,
       "version": "1.14.6"
     },
-    "cffi-1.14.6-py36h7f8727e_0.conda": {
-      "build": "py36h7f8727e_0",
-      "build_number": 0,
-      "depends": [
-        "libffi >=3.2.1,<3.3a0",
-        "libgcc-ng >=7.5.0",
-        "pycparser >=2.06",
-        "python >=3.6,<3.7.0a0"
-      ],
-      "license": "MIT",
-      "license_family": "MIT",
-      "md5": "59290f1943d6bae410e48855fdbcfb2c",
-      "name": "cffi",
-      "sha256": "789d14e61434921cc2b9f13123f2d6a5f310b46a54cf2420795b2073eddaa4d2",
-      "size": 227596,
-      "subdir": "linux-64",
-      "timestamp": 1625831738731,
-      "version": "1.14.6"
-    },
     "cffi-1.14.6-py37h400218f_0.conda": {
       "build": "py37h400218f_0",
       "build_number": 0,
@@ -549796,25 +549701,6 @@
       "timestamp": 1625814747956,
       "version": "1.14.6"
     },
-    "cffi-1.14.6-py37h7f8727e_0.conda": {
-      "build": "py37h7f8727e_0",
-      "build_number": 0,
-      "depends": [
-        "libffi >=3.2.1,<3.3a0",
-        "libgcc-ng >=7.5.0",
-        "pycparser >=2.06",
-        "python >=3.7,<3.8.0a0"
-      ],
-      "license": "MIT",
-      "license_family": "MIT",
-      "md5": "833254120db2177763a9fcb5b32505d2",
-      "name": "cffi",
-      "sha256": "60888e1aeb91f9633b660cac2955ad43912972e42e97fd47bd225ffbf87de126",
-      "size": 225987,
-      "subdir": "linux-64",
-      "timestamp": 1625831722937,
-      "version": "1.14.6"
-    },
     "cffi-1.14.6-py38h400218f_0.conda": {
       "build": "py38h400218f_0",
       "build_number": 0,
@@ -549833,25 +549719,6 @@
       "timestamp": 1625807894199,
       "version": "1.14.6"
     },
-    "cffi-1.14.6-py38h7f8727e_0.conda": {
-      "build": "py38h7f8727e_0",
-      "build_number": 0,
-      "depends": [
-        "libffi >=3.2.1,<3.3a0",
-        "libgcc-ng >=7.5.0",
-        "pycparser >=2.06",
-        "python >=3.8,<3.9.0a0"
-      ],
-      "license": "MIT",
-      "license_family": "MIT",
-      "md5": "4087128a3e90d106dae01690f5ca6ec9",
-      "name": "cffi",
-      "sha256": "d0035646928cda738ff3c5bfd1f498b3b0a508196c7700dd2c2ead1aa14f0457",
-      "size": 228059,
-      "subdir": "linux-64",
-      "timestamp": 1625831305203,
-      "version": "1.14.6"
-    },
     "cffi-1.14.6-py39h400218f_0.conda": {
       "build": "py39h400218f_0",
       "build_number": 0,
@@ -549870,25 +549737,6 @@
       "timestamp": 1625814763237,
       "version": "1.14.6"
     },
-    "cffi-1.14.6-py39h7f8727e_0.conda": {
-      "build": "py39h7f8727e_0",
-      "build_number": 0,
-      "depends": [
-        "libffi >=3.2.1,<3.3a0",
-        "libgcc-ng >=7.5.0",
-        "pycparser >=2.06",
-        "python >=3.9,<3.10.0a0"
-      ],
-      "license": "MIT",
-      "license_family": "MIT",
-      "md5": "625ed0c322094920ed903249d085c071",
-      "name": "cffi",
-      "sha256": "32a5e43004cc488b48e1a70a2afa409ef785508a53626a069b75bfbac7b85489",
-      "size": 230244,
-      "subdir": "linux-64",
-      "timestamp": 1625831731434,
-      "version": "1.14.6"
-    },
     "cfitsio-3.470-hb7c8383_2.conda": {
       "build": "hb7c8383_2",
       "build_number": 2,
@@ -943158,6 +943006,14 @@
     }
   },
   "removed": [
+    "cffi-1.14.6-py36h7f8727e_0.conda",
+    "cffi-1.14.6-py36h7f8727e_0.tar.bz2",
+    "cffi-1.14.6-py37h7f8727e_0.conda",
+    "cffi-1.14.6-py37h7f8727e_0.tar.bz2",
+    "cffi-1.14.6-py38h7f8727e_0.conda",
+    "cffi-1.14.6-py38h7f8727e_0.tar.bz2",
+    "cffi-1.14.6-py39h7f8727e_0.conda",
+    "cffi-1.14.6-py39h7f8727e_0.tar.bz2",
     "conda-package-handling-1.5.0-py27h7b6447c_0.conda",
     "conda-package-handling-1.5.0-py27h7b6447c_0.tar.bz2",
     "conda-package-handling-1.5.0-py36h7b6447c_0.conda",
 ```