### PR TITLE
Update `nomkl` requirements for openblas-devel 0.3.13

### DIFF
--- a/main.py
+++ b/main.py
@@ -594,7 +594,7 @@ def patch_record_in_place(fn, record, subdir):
         if not any(re.match(r'blas\s.*\smkl', dep) for dep in record['depends']):
             depends.append("blas * mkl")
 
-    if name == 'openblas':
+    if name in ('openblas', 'openblas-devel'):
         for i, dep in enumerate(depends):
             if dep.split()[0] == 'nomkl':
                 depends[i] = 'nomkl 3.0 0'


### PR DESCRIPTION
Needed to successfully install openblas=0.3.13 across all platforms; impacted packages:
```
linux-64/openblas-devel-0.3.13-h06a4308_0.conda {'nomkl 3.0 h06a4308_0'} => {'nomkl 3.0 0'}
linux-64/openblas-devel-0.3.13-h06a4308_0.tar.bz2 {'nomkl 3.0 h06a4308_0'} => {'nomkl 3.0 0'}
linux-aarch64/openblas-devel-0.3.10-hd43f75c_1.conda {'nomkl 3.0 hd43f75c_0'} => {'nomkl 3.0 0'}
linux-aarch64/openblas-devel-0.3.10-hd43f75c_1.tar.bz2 {'nomkl 3.0 hd43f75c_0'} => {'nomkl 3.0 0'}
linux-aarch64/openblas-devel-0.3.13-hd43f75c_1.conda {'nomkl 3.0 hd43f75c_0'} => {'nomkl 3.0 0'}
linux-aarch64/openblas-devel-0.3.13-hd43f75c_1.tar.bz2 {'nomkl 3.0 hd43f75c_0'} => {'nomkl 3.0 0'}
linux-ppc64le/openblas-devel-0.3.13-h6ffa863_0.conda {'nomkl 3.0 h6ffa863_0'} => {'nomkl 3.0 0'}
linux-ppc64le/openblas-devel-0.3.13-h6ffa863_0.tar.bz2 {'nomkl 3.0 h6ffa863_0'} => {'nomkl 3.0 0'}
linux-s390x/openblas-devel-0.3.10-ha847dfd_1.conda {'nomkl 3.0 ha847dfd_0'} => {'nomkl 3.0 0'}
linux-s390x/openblas-devel-0.3.10-ha847dfd_1.tar.bz2 {'nomkl 3.0 ha847dfd_0'} => {'nomkl 3.0 0'}
linux-s390x/openblas-devel-0.3.13-ha847dfd_0.conda {'nomkl 3.0 ha847dfd_0'} => {'nomkl 3.0 0'}
linux-s390x/openblas-devel-0.3.13-ha847dfd_0.tar.bz2 {'nomkl 3.0 ha847dfd_0'} => {'nomkl 3.0 0'}
osx-64/openblas-devel-0.3.13-hecd8cb5_0.conda {'nomkl 3.0 hecd8cb5_0'} => {'nomkl 3.0 0'}
osx-64/openblas-devel-0.3.13-hecd8cb5_0.tar.bz2 {'nomkl 3.0 hecd8cb5_0'} => {'nomkl 3.0 0'}
```

Fixes ContinuumIO/anaconda-issues#12342 (hopefully, for real this time)