### PR TITLE
Yank freetype 2.11.0 for Windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -47,11 +47,17 @@ REMOVALS = {
         "cffi-1.14.6-py38h9ed2024_0.tar.bz2",
         "cffi-1.14.6-py39h9ed2024_0.tar.bz2",
         ],
-    "win-32": ["nomkl-*"],
+    "win-32": [
+        "nomkl-*",
+        # This release/build breaks matplotlib and possibly other things well
+        "freetype-2.11.0-h88da6cb_0.tar.bz2",
+    ],
     "win-64": [
         "nomkl-*",
         # numba 0.46 didn't actually support py38
         "numba-0.46.0-py38hf9181ef_0.tar.bz2",
+        # This release/build breaks matplotlib and possibly other things well
+        "freetype-2.11.0-ha860e81_0.tar.bz2",
     ],
     "linux-64": [
         "numba-0.46.0-py38h962f231_0.tar.bz2",


### PR DESCRIPTION
This is breaking `matplotlib` (AnacondaRecipes/freetype-feedstock#3),
and it's quite possible, even likely, that this version/build will break
other things.  Yank freetype until we figure out what's going on.