### PR TITLE
Re-pin linux-aarch numpy 1.21.5 packages

### DIFF
--- a/main.py
+++ b/main.py
@@ -1029,6 +1029,16 @@ def patch_record_in_place(fn, record, subdir):
         if name == 'clangxx_osx-64' and version == '4.0.1' and int(build_number) < 17:
             depends[:] = ['clang_osx-64 >=4.0.1,<4.0.2.0a0', 'clangxx', 'libcxx']
 
+    # Correct packages mistakenly built against 1.21.5 on linux-aarch64
+    # Replaces the dependency bound with 1.21.2. These packages should
+    # actually have been built against an even earlier version of numpy.
+    # This is the safest correction we can make for now
+    if subdir == "linux-aarch64":
+        for i, dep in enumerate(depends):
+            if dep.startswith("numpy >=1.21.5,"):
+                depends[i] = depends[i].replace('>=1.21.5,', '>=1.21.2,')
+                break
+
 
 def replace_dep(depends, old, new):
     """ Replace a old dependency with a new one. """


### PR DESCRIPTION
We have been building packages against `numpy 1.21.5` on linux-aarch64, when we should have been building against an earlier version of NumPy for maximum forward compatibility. It looks like the reason for this is that the numpy version specificed in conda-build-config.yaml is ignored if a recipe uses an explicit version bound.

Those recipe issues need to be fixed, but in the meanwhile, here is a patch that relaxes a bound of 1.21.5 to 1.21.2. This is obviously not going to negatively impact anyone running 1.21.5 on linux-aarch64, but we have one partner use case where they are aligning on 1.21.2 between linux-64 and linux-aarch64. This patch allows the affected packages to be successfully be used in this case.

cc: @chenghlee 