### PR TITLE
Re-pin conda-libmamba-solver's libmambapy dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -988,6 +988,10 @@ def patch_record_in_place(fn, record, subdir):
                 if dep.startswith('python '):
                     depends[i] = "python >=3.7.1,<3.8.0a0"
 
+    # libmambapy 0.23 introduced breaking changes
+    if name == "conda-libmamba-solver":
+        replace_dep(depends, "libmambapy >=0.22.1", "libmambapy 0.22.*")
+
     ###########################
     # compilers and run times #
     ###########################


### PR DESCRIPTION
Avoid breaking API changes in libmambapy 0.23; fix #157.

X-ref: conda-forge/conda-forge-repodata-patches-feedstock#251