### PR TITLE
upper bound for cloudpickle for snowflake-snowpark-python

### DIFF
--- a/main.py
+++ b/main.py
@@ -999,6 +999,10 @@ def patch_record_in_place(fn, record, subdir):
     if name == "conda-libmamba-solver":
         replace_dep(depends, "libmambapy >=0.22.1", "libmambapy 0.22.*")
 
+    # snowflake-snowpark-python cloudpickle pins
+    if name == "snowflake-snowpark-python" and version == '0.6.0':
+        replace_dep(depends, 'cloudpickle >=1.6.0', 'cloudpickle >=1.6.0,<=2.0.0')
+
     ###########################
     # compilers and run times #
     ###########################


### PR DESCRIPTION
snowflake-snowpark-python needs to pin cloudpickle to 2.0.0 or less (yes, <=) according to the upstream authors. Version 0.7.0 already has the correct pin; only 0.6.0 is affected.

```
***************
*** 552125,552135 ****
        "build_number": 0,
        "constrains": [
          "pandas >1,<1.4"
        ],
        "depends": [
!         "cloudpickle >=1.6.0",
          "python >=3.8,<3.9.0a0",
          "snowflake-connector-python",
          "typing-extensions >=4.1.0"
        ],
        "license": "Apache-2.0",
--- 552125,552135 ----
        "build_number": 0,
        "constrains": [
          "pandas >1,<1.4"
        ],
        "depends": [
!         "cloudpickle >=1.6.0,<=2.0.0",
          "python >=3.8,<3.9.0a0",
          "snowflake-connector-python",
          "typing-extensions >=4.1.0"
        ],
        "license": "Apache-2.0",
```