### PR TITLE
fix cryptography upper bound after version schema change

### DIFF
--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ SUBDIRS = (
     "linux-ppc64le",
     "linux-s390x",
     "osx-64",
+    "osx-arm64",
     "win-32",
     "win-64",
 )

--- a/main.py
+++ b/main.py
@@ -1015,10 +1015,18 @@ def patch_record_in_place(fn, record, subdir):
     if name == "aiobotocore" and version.startswith("1.2."):
         replace_dep(depends, "botocore", "botocore >=1.19.52,<1.19.53")
 
-    # pyjwt 2.1.0 has incorrect depends/constrains on cryptography
+    # cryptography changed its versioning convention
+    # see https://cryptography.io/en/latest/api-stability/#versioning
     if name == "pyjwt" and version == "2.1.0":
+        # pyjwt 2.1.0 has incorrect depends/constrains on cryptography
         depends[:] = list(d for d in depends if not d.startswith("cryptography "))
-        record["constrains"] = ["cryptography >=3.3.1,<4.0.0"]
+        record["constrains"] = ["cryptography >=3.3.1,<40.0.0"]
+    if name == "authlib" and version == "0.15.4":
+        replace_dep(depends, "cryptography >=3.2,<4", "cryptography >=3.2,<40.0.0a0")
+    if name == "flask-jwt-extended" and version == "4.2.3":
+        replace_dep(depends, "cryptography >=3.0,<4.0", "cryptography >=3.0,<40.0.0a0")
+    if name == "oauthlib" and (version == "3.1.1" or version == "3.2.0"):
+        replace_dep(depends, "cryptography >=3.0.0,<4", "cryptography >=3.0.0,<40.0.0a0")
 
     if name == "pyerfa" and version == "2.0.0":
         replace_dep(depends, "numpy >=1.17", "numpy >=1.20.2,<2.0a0")


### PR DESCRIPTION
The cryptography package has started using a new versioning scheme. It jumped to v35.0.0 after v3.4.8. - https://cryptography.io/en/latest/api-stability/#versioning. cryptography provided py310 support in v36.0.0 and the latest version is 37.0.1.
However, several Anaconda packages have version checks like cryptography >=3.0.0,<4 . This means that the new cryptography package is not picked up. This leads to conflicts when trying to build and install various other, higher-level packages.

See: https://cryptography.io/en/latest/api-stability/#versioning

Jira: https://anaconda.atlassian.net/browse/DSNC-5011

Packages depending on cryptography:
https://metayaml-conda.fly.dev/metayaml/reverse_dependencies?name=cryptography

Note: I had to add osx-arm64 to the lists of subdirs in main.py

linux-64 diff (other architectures have similar diffs)
`
*** main/linux-64/repodata-reference.json       2022-08-02 16:17:13.000000000 -0400
--- main/linux-64/repodata-patched.json 2022-08-02 16:17:23.000000000 -0400
***************
*** 384419,384429 ****
      },
      "pyjwt-2.1.0-py310h06a4308_0.tar.bz2": {
        "build": "py310h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.10,<3.11.0a0"
        ],
        "license": "MIT",
--- 384419,384429 ----
      },
      "pyjwt-2.1.0-py310h06a4308_0.tar.bz2": {
        "build": "py310h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.10,<3.11.0a0"
        ],
        "license": "MIT",
***************
*** 384438,384448 ****
      },
      "pyjwt-2.1.0-py36h06a4308_0.tar.bz2": {
        "build": "py36h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.6,<3.7.0a0"
        ],
        "license": "MIT",
--- 384438,384448 ----
      },
      "pyjwt-2.1.0-py36h06a4308_0.tar.bz2": {
        "build": "py36h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.6,<3.7.0a0"
        ],
        "license": "MIT",
***************
*** 384457,384467 ****
      },
      "pyjwt-2.1.0-py37h06a4308_0.tar.bz2": {
        "build": "py37h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.7,<3.8.0a0"
        ],
        "license": "MIT",
--- 384457,384467 ----
      },
      "pyjwt-2.1.0-py37h06a4308_0.tar.bz2": {
        "build": "py37h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.7,<3.8.0a0"
        ],
        "license": "MIT",
***************
*** 384476,384486 ****
      },
      "pyjwt-2.1.0-py38h06a4308_0.tar.bz2": {
        "build": "py38h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.8,<3.9.0a0"
        ],
        "license": "MIT",
--- 384476,384486 ----
      },
      "pyjwt-2.1.0-py38h06a4308_0.tar.bz2": {
        "build": "py38h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.8,<3.9.0a0"
        ],
        "license": "MIT",
***************
*** 384495,384505 ****
      },
      "pyjwt-2.1.0-py39h06a4308_0.tar.bz2": {
        "build": "py39h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.9,<3.10.0a0"
        ],
        "license": "MIT",
--- 384495,384505 ----
      },
      "pyjwt-2.1.0-py39h06a4308_0.tar.bz2": {
        "build": "py39h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.9,<3.10.0a0"
        ],
        "license": "MIT",
***************
*** 931087,931097 ****
      },
      "pyjwt-2.1.0-py310h06a4308_0.conda": {
        "build": "py310h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.10,<3.11.0a0"
        ],
        "license": "MIT",
--- 931087,931097 ----
      },
      "pyjwt-2.1.0-py310h06a4308_0.conda": {
        "build": "py310h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.10,<3.11.0a0"
        ],
        "license": "MIT",
***************
*** 931106,931116 ****
      },
      "pyjwt-2.1.0-py36h06a4308_0.conda": {
        "build": "py36h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.6,<3.7.0a0"
        ],
        "license": "MIT",
--- 931106,931116 ----
      },
      "pyjwt-2.1.0-py36h06a4308_0.conda": {
        "build": "py36h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.6,<3.7.0a0"
        ],
        "license": "MIT",
***************
*** 931125,931135 ****
      },
      "pyjwt-2.1.0-py37h06a4308_0.conda": {
        "build": "py37h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.7,<3.8.0a0"
        ],
        "license": "MIT",
--- 931125,931135 ----
      },
      "pyjwt-2.1.0-py37h06a4308_0.conda": {
        "build": "py37h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.7,<3.8.0a0"
        ],
        "license": "MIT",
***************
*** 931144,931154 ****
      },
      "pyjwt-2.1.0-py38h06a4308_0.conda": {
        "build": "py38h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.8,<3.9.0a0"
        ],
        "license": "MIT",
--- 931144,931154 ----
      },
      "pyjwt-2.1.0-py38h06a4308_0.conda": {
        "build": "py38h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.8,<3.9.0a0"
        ],
        "license": "MIT",
***************
*** 931163,931173 ****
      },
      "pyjwt-2.1.0-py39h06a4308_0.conda": {
        "build": "py39h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<4.0.0"
        ],
        "depends": [
          "python >=3.9,<3.10.0a0"
        ],
        "license": "MIT",
--- 931163,931173 ----
      },
      "pyjwt-2.1.0-py39h06a4308_0.conda": {
        "build": "py39h06a4308_0",
        "build_number": 0,
        "constrains": [
!         "cryptography >=3.3.1,<40.0.0"
        ],
        "depends": [
          "python >=3.9,<3.10.0a0"
        ],
        "license": "MIT",
`

noarch diff:
`
*** main/noarch/repodata-reference.json 2022-08-02 16:18:04.000000000 -0400
--- main/noarch/repodata-patched.json   2022-08-02 16:18:10.000000000 -0400
***************
*** 4356,4366 ****
      },
      "authlib-0.15.4-pyhd3eb1b0_0.tar.bz2": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
!         "cryptography >=3.2,<4",
          "python >=2.7",
          "requests"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
--- 4356,4366 ----
      },
      "authlib-0.15.4-pyhd3eb1b0_0.tar.bz2": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
!         "cryptography >=3.2,<40.0.0a0",
          "python >=2.7",
          "requests"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
***************
*** 27133,27143 ****
      },
      "flask-jwt-extended-4.2.3-pyhd3eb1b0_0.tar.bz2": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
!         "cryptography >=3.0,<4.0",
          "flask >=1.0,<3.0",
          "pyjwt >=2.0,<3.0",
          "python >=3.6,<4",
          "werkzeug >=0.14"
        ],
--- 27133,27143 ----
      },
      "flask-jwt-extended-4.2.3-pyhd3eb1b0_0.tar.bz2": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
!         "cryptography >=3.0,<40.0.0a0",
          "flask >=1.0,<3.0",
          "pyjwt >=2.0,<3.0",
          "python >=3.6,<4",
          "werkzeug >=0.14"
        ],
***************
*** 57709,57719 ****
      "oauthlib-3.1.1-pyhd3eb1b0_0.tar.bz2": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
          "blinker >=1.4.0",
!         "cryptography >=3.0.0,<4",
          "pyjwt >=2.0.0,<3",
          "python >=3.6"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
--- 57709,57719 ----
      "oauthlib-3.1.1-pyhd3eb1b0_0.tar.bz2": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
          "blinker >=1.4.0",
!         "cryptography >=3.0.0,<40.0.0a0",
          "pyjwt >=2.0.0,<3",
          "python >=3.6"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
***************
*** 57729,57739 ****
      "oauthlib-3.2.0-pyhd3eb1b0_0.tar.bz2": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
          "blinker >=1.4.0",
!         "cryptography >=3.0.0,<4",
          "pyjwt >=2.0.0,<3",
          "python >=3.6"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
--- 57729,57739 ----
      "oauthlib-3.2.0-pyhd3eb1b0_0.tar.bz2": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
          "blinker >=1.4.0",
!         "cryptography >=3.0.0,<40.0.0a0",
          "pyjwt >=2.0.0,<3",
          "python >=3.6"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
***************
*** 93960,93970 ****
      },
      "authlib-0.15.4-pyhd3eb1b0_0.conda": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
!         "cryptography >=3.2,<4",
          "python >=2.7",
          "requests"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
--- 93960,93970 ----
      },
      "authlib-0.15.4-pyhd3eb1b0_0.conda": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
!         "cryptography >=3.2,<40.0.0a0",
          "python >=2.7",
          "requests"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
***************
*** 115409,115419 ****
      },
      "flask-jwt-extended-4.2.3-pyhd3eb1b0_0.conda": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
!         "cryptography >=3.0,<4.0",
          "flask >=1.0,<3.0",
          "pyjwt >=2.0,<3.0",
          "python >=3.6,<4",
          "werkzeug >=0.14"
        ],
--- 115409,115419 ----
      },
      "flask-jwt-extended-4.2.3-pyhd3eb1b0_0.conda": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
!         "cryptography >=3.0,<40.0.0a0",
          "flask >=1.0,<3.0",
          "pyjwt >=2.0,<3.0",
          "python >=3.6,<4",
          "werkzeug >=0.14"
        ],
***************
*** 138653,138663 ****
      "oauthlib-3.1.1-pyhd3eb1b0_0.conda": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
          "blinker >=1.4.0",
!         "cryptography >=3.0.0,<4",
          "pyjwt >=2.0.0,<3",
          "python >=3.6"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
--- 138653,138663 ----
      "oauthlib-3.1.1-pyhd3eb1b0_0.conda": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
          "blinker >=1.4.0",
!         "cryptography >=3.0.0,<40.0.0a0",
          "pyjwt >=2.0.0,<3",
          "python >=3.6"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
***************
*** 138673,138683 ****
      "oauthlib-3.2.0-pyhd3eb1b0_0.conda": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
          "blinker >=1.4.0",
!         "cryptography >=3.0.0,<4",
          "pyjwt >=2.0.0,<3",
          "python >=3.6"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
--- 138673,138683 ----
      "oauthlib-3.2.0-pyhd3eb1b0_0.conda": {
        "build": "pyhd3eb1b0_0",
        "build_number": 0,
        "depends": [
          "blinker >=1.4.0",
!         "cryptography >=3.0.0,<40.0.0a0",
          "pyjwt >=2.0.0,<3",
          "python >=3.6"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
`



