### PR TITLE
slight relaxation of scipy for linux-64 tensorflow-base 2.8.2

### DIFF
--- a/main.py
+++ b/main.py
@@ -682,6 +682,14 @@ def patch_record_in_place(fn, record, subdir):
     if name.startswith("tensorflow-base") and version == "2.4.1":
         replace_dep(depends, "gast", "gast 0.3.3")
 
+    # Relax the scipy pin slightly on linux-64 for tensorflow-base 2.8.2
+    # to match linux-aarch64, to facilitate intel/arm version alignment.
+    if name.startswith("tensorflow-base") and version == "2.8.2" and subdir == 'linux-64':
+        for i, dep in enumerate(depends):
+            if dep == "scipy >=1.7.3":
+                depends[i] = "scipy >=1.7.1"
+                break
+
     ##############
     # constrains #
     ##############


### PR DESCRIPTION
This relaxes the tensorflow-base-2.8.2 scipy deps from `scipy >=1.7.3` to `scipy >=1.7.1`. This is to ensure that we can create environments for linux-64 and linux-aarch64 with synchronized versions of scipy and tensorflow 2.8. Our team has confidence in compatibility at the binary level for this relaxation.