### PR TITLE
add numpy constraints for numba 0.54.1 and 0.55.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -992,6 +992,11 @@ def patch_record_in_place(fn, record, subdir):
     if name == "numba" and version in ["0.46.0", "0.47.0"]:
         depends.append("setuptools")
 
+    # numba 0.54.1 0.55.0 have the wrong numpy bounds set
+    # see for each version: https://github.com/numba/numba/blob/0.54.1/numba/__init__.py#L135
+    if name == "numba" and version in ["0.54.1", "0.55.0"]:
+        record["constrains"] = ["numpy >=1.17,<=1.20"]
+
     # python-language-server should contrains ujson <=1.35
     # see https://github.com/conda-forge/cf-mark-broken/pull/20
     # https://github.com/conda-forge/python-language-server-feedstock/pull/48

--- a/main.py
+++ b/main.py
@@ -993,9 +993,12 @@ def patch_record_in_place(fn, record, subdir):
         depends.append("setuptools")
 
     # numba 0.54.1 0.55.0 have the wrong numpy bounds set
-    # see for each version: https://github.com/numba/numba/blob/0.54.1/numba/__init__.py#L135
-    if name == "numba" and version in ["0.54.1", "0.55.0"]:
+    # see https://github.com/numba/numba/blob/0.54.1/numba/__init__.py#L135
+    # see https://github.com/numba/numba/blob/0.55.0/numba/__init__.py#L137
+    if name == "numba" and version == "0.54.1":
         record["constrains"] = ["numpy >=1.17,<=1.20"]
+    if name == "numba" and version == "0.55.0":
+        record["constrains"] = ["numpy >=1.18,<=1.21"]
 
     # python-language-server should contrains ujson <=1.35
     # see https://github.com/conda-forge/cf-mark-broken/pull/20


### PR DESCRIPTION
numba has numpy requirements enforced through imports checks.

For 0.55.1 and above the bounds are set correctly
For 0.53.1 and below numba doesn't set upper bounds.
0.54.1 and 0.55.0 are not set properly.

This PR adds a run constraint to match numba code:
https://github.com/numba/numba/blob/0.54.1/numba/__init__.py#L135
https://github.com/numba/numba/blob/0.55.0/numba/__init__.py#L137