### PR TITLE
adjusting numpy upperbound for numba 0.54 0.55

### DIFF
--- a/main.py
+++ b/main.py
@@ -997,9 +997,9 @@ def patch_record_in_place(fn, record, subdir):
     # see https://github.com/numba/numba/blob/0.54.1/numba/__init__.py#L135
     # see https://github.com/numba/numba/blob/0.55.0/numba/__init__.py#L137
     if name == "numba" and version in ("0.54.0", "0.54.1"):
-        record["constrains"] = ["numpy >=1.17,<=1.20"]
+        record["constrains"] = ["numpy >=1.17,<1.21.0a0"]
     if name == "numba" and version == "0.55.0":
-        record["constrains"] = ["numpy >=1.18,<=1.21"]
+        record["constrains"] = ["numpy >=1.18,<1.22.0a0"]
 
     # python-language-server should contrains ujson <=1.35
     # see https://github.com/conda-forge/cf-mark-broken/pull/20


### PR DESCRIPTION
Numba has numpy constraints that were not handled in conda packages 0.54.0 0.54.1 and 0.55.0.

The numpy constraint added via hotfix in PR #170 and #171 are too strict and break installation of anaconda 2021.11. (See #172).

This change corrects the constraints.

See:
https://github.com/numba/numba/blob/0.54.1/numba/__init__.py#L137
https://github.com/numba/numba/blob/0.54.1/numba/np/numpy_support.py#L15
https://github.com/numba/numba/blob/0.55.0/numba/__init__.py#L139
https://github.com/numba/numba/blob/0.55.0/numba/np/numpy_support.py#L16