### PR TITLE
second fix for conda-libmamba-solver constrains

### DIFF
--- a/main.py
+++ b/main.py
@@ -1105,8 +1105,14 @@ def patch_record_in_place(fn, record, subdir):
 
     if name == "conda" and version in ("22.11.0", "22.11.1"):
         # exclude all pre-plugin-system libmambapy/conda-libmamba-solver
-        constrains += ["conda-libmamba-solver >=22.11.0"]
-        replace_dep(depends, "ruamel.yaml >=0.11.14,<0.17", "ruamel.yaml >=0.11.14,<0.18")
+        constrains[:] = [
+            dep
+            for dep in constrains
+            if not dep.startswith("conda-libmamba-solver")
+        ] + ["conda-libmamba-solver >=22.12.0"]
+        replace_dep(
+            depends, "ruamel.yaml >=0.11.14,<0.17", "ruamel.yaml >=0.11.14,<0.18"
+        )
 
     if name == "conda-libmamba-solver":
         # libmambapy 0.23 introduced breaking changes


### PR DESCRIPTION
Update conda-libmamba-solver version; avoid duplicate conda-libmamba-solver constrains if new 22.11.x build has it.

We decided to release a new build number with updated metadata instead of relying completely on hotfixes, so the improved hotfix should avoid a (harmless) duplicate constraint.