### PR TITLE
pin conda <23.1 in conda-libmamba-solver

### DIFF
--- a/main.py
+++ b/main.py
@@ -1122,6 +1122,9 @@ def patch_record_in_place(fn, record, subdir):
             replace_dep(depends, "conda >=4.12", "conda >=4.13")
         # conda 22.11 introduces the plugin system
         replace_dep(depends, "conda >=4.13", "conda >=4.13,<22.11.0a")
+        # conda 23.1 changed an internal SubdirData API needed for S3/FTP channels
+        replace_dep(depends, "conda >=22.11.0", "conda >=22.11.0,<23.1.0a")
+
 
     # snowflake-snowpark-python cloudpickle pins
     if name == "snowflake-snowpark-python" and version == '0.6.0':

--- a/main.py
+++ b/main.py
@@ -1125,7 +1125,6 @@ def patch_record_in_place(fn, record, subdir):
         # conda 23.1 changed an internal SubdirData API needed for S3/FTP channels
         replace_dep(depends, "conda >=22.11.0", "conda >=22.11.0,<23.1.0a")
 
-
     # snowflake-snowpark-python cloudpickle pins
     if name == "snowflake-snowpark-python" and version == '0.6.0':
         replace_dep(depends, 'cloudpickle >=1.6.0', 'cloudpickle >=1.6.0,<=2.0.0')


### PR DESCRIPTION
Comes from https://github.com/conda/conda-libmamba-solver/issues/113.

Prevent breakage by an API change.