### PR TITLE
Recent jinja2 are no longer a problem for conda-build

### DIFF
--- a/main.py
+++ b/main.py
@@ -816,6 +816,11 @@ def patch_record_in_place(fn, record, subdir):
     if name == "conda-build":
         for i, dep in enumerate(depends):
             dep_name, *other = dep.split()
+            # Jinja 3.0.0 introduced behavior changes that broke certain
+            # conda-build templating functionality.
+            if dep_name == "jinja2":
+                depends[i] = "jinja2 !=3.0.0"
+
             # Deprecation removed in conda 4.13 break older conda-builds
             if VersionOrder(version) <= VersionOrder("3.21.8") and dep_name == "conda":
                 depends[i] = "{} {}<4.13.0".format(

--- a/main.py
+++ b/main.py
@@ -816,15 +816,6 @@ def patch_record_in_place(fn, record, subdir):
     if name == "conda-build":
         for i, dep in enumerate(depends):
             dep_name, *other = dep.split()
-            # Jinja 3.0.0 introduced behavior changes that broke certain
-            # conda-build templating functionality.
-            #
-            # TODO: Review the conda-build and/or jinja version bounds on new
-            # releases of those packages; at some point, the incompatibilities
-            # between conda-build and jinja >=3.0 should be resolved.
-            if dep_name == "jinja2":
-                depends[i] = "jinja2 <3.0.0a0"
-
             # Deprecation removed in conda 4.13 break older conda-builds
             if VersionOrder(version) <= VersionOrder("3.21.8") and dep_name == "conda":
                 depends[i] = "{} {}<4.13.0".format(


### PR DESCRIPTION
With conda's tests depending on flask and jinja2 through conda-build, and jinja2 3.0.1 / 3.0.2 which may fix the issue being rather old by now, drop this problematic constraint.

https://metayaml-conda.fly.dev/metayaml/newest_by_platform?name=jinja2

Should we express a "this jinja2 version is not allowed" dependency?