### PR TITLE
limit effect of conda-libmamba-solver pin

### DIFF
--- a/main.py
+++ b/main.py
@@ -1119,7 +1119,9 @@ def patch_record_in_place(fn, record, subdir):
         # conda 22.11 introduces the plugin system
         replace_dep(depends, "conda >=4.13", "conda >=4.13,<22.11.0a")
         # conda 23.1 changed an internal SubdirData API needed for S3/FTP channels
-        replace_dep(depends, "conda >=22.11.0", "conda >=22.11.0,<23.1.0a")
+        if VersionOrder(version) < VersionOrder("23.1.0a0"):
+            # https://github.com/conda/conda-libmamba-solver/issues/132
+            replace_dep(depends, "conda >=22.11.0", "conda >=22.11.0,<23.1.0a")
 
     # snowflake-snowpark-python cloudpickle pins
     if name == "snowflake-snowpark-python" and version == '0.6.0':


### PR DESCRIPTION
Comes from https://github.com/conda/conda-libmamba-solver/issues/132

Without this change, conda-libmamba-solver 23.1.0 (which is compatible with conda 23) is also patched.