### PR TITLE
comment flask click and itsdangerous restrictions

### DIFF
--- a/main.py
+++ b/main.py
@@ -1021,8 +1021,9 @@ def patch_record_in_place(fn, record, subdir):
     # Version 1.1.4 will be maintained in a separate branch:
     # https://github.com/AnacondaRecipes/flask-feedstock/tree/main-1.1.x
     if name == "flask" and version[0] == "1" and int(version[-1]) < 4:
-        replace_dep(depends, "click >=5.1", "click >=5.1,<8.0")
-        replace_dep(depends, "itsdangerous >=0.24", "itsdangerous >=0.24,<2.0")
+        # the two next lines are commented as they break older anaconda distributions (2022.05)
+        # replace_dep(depends, "click >=5.1", "click >=5.1,<8.0")
+        # replace_dep(depends, "itsdangerous >=0.24", "itsdangerous >=0.24,<2.0")
         replace_dep(depends, "jinja2 >=2.10.1", "jinja2 >=2.10.1,<3.0")
         replace_dep(depends, "jinja2 >=2.10", "jinja2 >=2.10,<3.0")
         replace_dep(depends, "werkzeug >=0.14", "werkzeug >=0.15,<2.0")


### PR DESCRIPTION
Following PR #184, older versions of anaconda fail to install:

conda create -n anaconda-2022.05_py39 anaconda==2022.05 python=3.9

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package flask-1.1.2-pyhd3eb1b0_0 requires click >=5.1,<8.0, but none of the providers can be installed

It seems we can do away without the added restrictions on click and itsdangerous.
