### PR TITLE
NAV-917: conda constrained for old navigator releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: |
           conda activate testenv
           echo "################## main ###########################"
-          python test-hotfix.py main --subdir noarch linux-32 linux-64 linux-aarch64 linux-ppc64le linux-s390x osx-64 win-32 win-64
+          python test-hotfix.py main --subdir noarch linux-32 linux-64 linux-aarch64 linux-ppc64le linux-s390x osx-64 osx-arm64 win-32 win-64
           echo "################## r    ###########################"
           python test-hotfix.py r --subdir noarch linux-32 linux-64 linux-aarch64 linux-ppc64le osx-64 win-32 win-64
           echo "###################################################"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: help init check lint lint-flake8 test test-hotfix test-pytest
+
+PREFIX = $(shell conda info | grep -q 'repodata-hotfixes' || echo 'conda run -n repodata-hotfixes')
+
+help:
+	@echo 'Usage: make [COMMAND] ...'
+	@echo ''
+	@echo 'Commands:'
+	@echo '  init         initialize development environment'
+	@echo '  check        check the project for any issues (see: lint, test)'
+	@echo '  lint         run all linters for the project (see: lint-flake8)'
+	@echo '  lint-flake8  check source code for PEP8 compliance'
+	@echo '  test         run all automated tests (see: test-pytest, test-hotfix)'
+	@echo '  test-hotfix  test your repodata change'
+	@echo '  test-pytest  run unit tests'
+
+init:
+	@if [ -z "$${CONDA_SHLVL:+x}" ]; then echo "Conda is not installed." && exit 1; fi
+	@conda create -y -n repodata-hotfixes conda conda-build flake8 pytest requests
+
+check: lint test
+
+lint: lint-flake8
+
+lint-flake8:
+	@${PREFIX} flake8 --count .
+
+test: test-pytest test-hotfix
+
+test-hotfix:
+	@${PREFIX} python test-hotfix.py main --subdir noarch linux-32 linux-64 linux-aarch64 linux-ppc64le linux-s390x osx-64 osx-arm64 win-32 win-64
+
+test-pytest:
+	@${PREFIX} pytest -v tests/

--- a/main.py
+++ b/main.py
@@ -1242,25 +1242,22 @@ def replace_dep(depends, old, new, *, append=False):
     """
     if isinstance(old, str):
         old = [old]
+    if append and (new is None):
+        raise TypeError('Forbidden to append None to dependencies')
 
+    removed = False
     for item in old:
-        try:
-            index = depends.index(item)
-        except ValueError:
-            continue
-        if new is None:
-            del depends[index]
-            return '-'
-        depends[index] = new
-        return '~'
+        if item in depends:
+            depends.remove(item)
+            removed = True
 
-    if append:
-        if new is None:
-            raise TypeError('Forbidden to append None to dependencies')
-        if new not in depends:
-            bisect.insort_left(depends, new)
-            return '+'
-
+    if (removed or append) and (new is not None) and (new not in depends):
+        bisect.insort_left(depends, new)
+        if removed:
+            return '~'
+        return '+'
+    if removed:
+        return '-'
     return '='
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+"""Unit tests for repodata hotfix components."""

--- a/tests/test_replace_dep.py
+++ b/tests/test_replace_dep.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for :func:`~main.replace_dep`."""
+
+from __future__ import annotations
+
+__all__ = ()
+
+import typing
+
+import pytest
+
+from main import replace_dep
+
+
+def test_fail_append_removing() -> None:
+    """Make sure that :func:`~main.replace_dep` raises exception on inappropriate use."""
+    with pytest.raises(TypeError):
+        replace_dep([], 'any >=1.0.0', None, append=True)
+
+
+@pytest.mark.parametrize(
+    ['old', 'new', 'append', 'expected_outcome', 'expected_dependencies'],
+    [
+        # delete
+        pytest.param(
+            'pytest >=7.2.2', None, None,
+            '-', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'zstandard >=0.20.0',
+            ],
+            id='delete_existing',
+        ),
+        pytest.param(
+            'flask >=2.2.3', None, None,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='delete_missing',
+        ),
+        pytest.param(
+            ['django >=4.1.7', 'flask >=2.2.3'], None, None,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='delete_none_of',
+        ),
+        pytest.param(
+            ['anaconda-client >=1.11.1', 'conda >=23.1.0', 'django >=4.1.7', 'zstandard >=0.20.0'], None, None,
+            '-', [
+                'attrs >=22.2.0', 'pytest >=7.2.2',
+            ],
+            id='delete_some_of',
+        ),
+
+        # insert
+        pytest.param(
+            [], 'attrs >=22.2.0', True,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='insert_duplicate',
+        ),
+        pytest.param(
+            [], 'django >=4.1.7', True,
+            '+', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'django >=4.1.7', 'pytest >=7.2.2',
+                'zstandard >=0.20.0',
+            ],
+            id='insert_unique',
+        ),
+
+        # update
+        pytest.param(
+            'pytest >=7.2.2', 'attrs >=22.2.0', None,
+            '-', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'zstandard >=0.20.0',
+            ],
+            id='update_existing_with_duplicate',
+        ),
+        pytest.param(
+            'pytest >=7.2.2', 'pytest >=7.0.0', None,
+            '~', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.0.0', 'zstandard >=0.20.0',
+            ],
+            id='update_existing_with_unique',
+        ),
+        pytest.param(
+            'django >=4.1.7', 'conda >=23.1.0', None,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='update_missing_with_duplicate',
+        ),
+        pytest.param(
+            'django >=4.1.7', 'django >=4.0.0', None,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='update_missing_with_unique',
+        ),
+        pytest.param(
+            ['django >=4.1.7', 'flask >=2.2.3'], 'zstandard >=0.20.0', None,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='update_none_of_with_duplicate',
+        ),
+        pytest.param(
+            ['django >=4.1.7', 'flask >=2.2.3'], 'mypy >=1.0.0', None,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='update_none_of_with_unique',
+        ),
+        pytest.param(
+            ['attrs >=22.2.0', 'mypy >=1.0.1', 'pytest >=7.2.2'], 'anaconda-client >=1.11.1', None,
+            '-', [
+                'anaconda-client >=1.11.1', 'conda >=23.1.0', 'zstandard >=0.20.0',
+            ],
+            id='update_some_of_with_duplicate',
+        ),
+        pytest.param(
+            ['attrs >=22.2.0', 'mypy >=1.0.1', 'pytest >=7.2.2'], 'mypy >=1.0.0', None,
+            '~', [
+                'anaconda-client >=1.11.1', 'conda >=23.1.0', 'mypy >=1.0.0', 'zstandard >=0.20.0',
+            ],
+            id='update_some_of_with_unique',
+        ),
+
+        # upsert
+        pytest.param(
+            'pytest >=7.2.2', 'attrs >=22.2.0', True,
+            '-', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'zstandard >=0.20.0',
+            ],
+            id='upsert_existing_with_duplicate',
+        ),
+        pytest.param(
+            'pytest >=7.2.2', 'pytest >=7.0.0', True,
+            '~', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.0.0', 'zstandard >=0.20.0',
+            ],
+            id='upsert_existing_with_unique',
+        ),
+        pytest.param(
+            'django >=4.1.7', 'conda >=23.1.0', True,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='upsert_missing_with_duplicate',
+        ),
+        pytest.param(
+            'django >=4.1.7', 'django >=4.0.0', True,
+            '+', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'django >=4.0.0', 'pytest >=7.2.2',
+                'zstandard >=0.20.0',
+            ],
+            id='upsert_missing_with_unique',
+        ),
+        pytest.param(
+            ['django >=4.1.7', 'flask >=2.2.3'], 'zstandard >=0.20.0', True,
+            '=', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'pytest >=7.2.2', 'zstandard >=0.20.0',
+            ],
+            id='upsert_none_of_with_duplicate',
+        ),
+        pytest.param(
+            ['django >=4.1.7', 'flask >=2.2.3'], 'mypy >=1.0.0', True,
+            '+', [
+                'anaconda-client >=1.11.1', 'attrs >=22.2.0', 'conda >=23.1.0', 'mypy >=1.0.0', 'pytest >=7.2.2',
+                'zstandard >=0.20.0',
+            ],
+            id='upsert_none_of_with_unique',
+        ),
+        pytest.param(
+            ['attrs >=22.2.0', 'mypy >=1.0.1', 'pytest >=7.2.2'], 'anaconda-client >=1.11.1', True,
+            '-', [
+                'anaconda-client >=1.11.1', 'conda >=23.1.0', 'zstandard >=0.20.0',
+            ],
+            id='upsert_some_of_with_duplicate',
+        ),
+        pytest.param(
+            ['attrs >=22.2.0', 'mypy >=1.0.1', 'pytest >=7.2.2'], 'mypy >=1.0.0', True,
+            '~', [
+                'anaconda-client >=1.11.1', 'conda >=23.1.0', 'mypy >=1.0.0', 'zstandard >=0.20.0',
+            ],
+            id='upsert_some_of_with_unique',
+        ),
+    ],
+)
+def test_replace_dep(
+        old: str | typing.Iterable[str],
+        new: str | None,
+        append: bool | None,
+        expected_outcome: str,
+        expected_dependencies: list[str],
+) -> None:
+    """Check behavior of the :func:`~main.replace_dep`."""
+    depends: list[str] = [
+        'anaconda-client >=1.11.1',
+        'attrs >=22.2.0',
+        'conda >=23.1.0',
+        'pytest >=7.2.2',
+        'zstandard >=0.20.0',
+    ]
+
+    kwargs: dict[str, typing.Any] = {}
+    if append is not None:
+        kwargs['append'] = append
+
+    assert replace_dep(depends, old, new, **kwargs) == expected_outcome
+    assert depends == expected_dependencies


### PR DESCRIPTION
Fixed issues:
- `anaconda-navigator<2.4.0` doesn't completely support `conda>=23.1.0`
- `anaconda-navigator<2.3.0` doesn't completely support `pyqt>=5.15,<6.0a0`
- `anaconda-navigator` has issues with `conda>=22.11.0,<23.1.0`
- `anaconda-client<1.10.0` is incompatible with python 3.10