### PR TITLE
Versioneer license_family hotfix

### DIFF
--- a/main.py
+++ b/main.py
@@ -511,7 +511,7 @@ def patch_record(fn, record, subdir, instructions, index):
     # to the patch instructions
     original_record = copy.deepcopy(record)
     patch_record_in_place(fn, record, subdir)
-    keys_to_check = ["depends", "constrains", "namespace", "track_features", "features"]
+    keys_to_check = ["depends", "constrains", "namespace", "track_features", "features", "license_family"]
     for key in keys_to_check:
         if record.get(key) != original_record.get(key):
             instructions["packages"][fn][key] = record.get(key)

--- a/main.py
+++ b/main.py
@@ -751,6 +751,13 @@ def patch_record_in_place(fn, record, subdir):
                 break
 
     ##############
+    # versioneer #
+    ##############
+
+    if name == "versioneer" and record["license_family"].upper() == "NONE":
+        record["license_family"] = "PUBLIC-DOMAIN"
+
+    ##############
     # constrains #
     ##############
 


### PR DESCRIPTION
The `license_family` value of `versioneer` was incorrectly set to `None` (should have been `PUBLIC-DOMAIN`.

This introduced additional problems when uploading to anaconda.cloud as the schema does not recognize `"None"` (only `None`/`null`).

# Changes

* Check `license_family` field when creating patch instructions
* Change versioneer `license_family` to `PUBLIC-DOMAIN` if `None`

Hotfix log: [test-hotfix.log](https://github.com/AnacondaRecipes/repodata-hotfixes/files/11390679/test-hotfix.log)
