### PR TITLE
Changes to lead to OpenSSL 3

### DIFF
--- a/main.py
+++ b/main.py
@@ -893,6 +893,11 @@ def patch_record_in_place(fn, record, subdir):
     # openssl >=1.1.1,<1.1.2.0a0 -> >=1.1.1a,<1.1.2a
     replace_dep(depends, "openssl >=1.1.1,<1.1.2.0a0", "openssl >=1.1.1a,<1.1.2a")
 
+    # openssl3 preventive measures
+    replace_dep(depends, "openssl !=1.1.1e", "openssl !=1.1.1e,<1.1.2a")
+    if name != "_anaconda_depends":
+        replace_dep(depends, "openssl", "openssl<1.1.2a")
+
     # kealib 1.4.8 changed sonames, add new upper bound to existing packages
     replace_dep(depends, "kealib >=1.4.7,<1.5.0a0", "kealib >=1.4.7,<1.4.8.0a0")
 

--- a/main.py
+++ b/main.py
@@ -919,12 +919,13 @@ def patch_record_in_place(fn, record, subdir):
     # run_exports mis-pins #
     ########################
 
-    # openssl uses funnny version numbers, 1.1.1, 1.1.1a, 1.1.1b, etc
+    # openssl 1.1.1 uses funnny version numbers, 1.1.1, 1.1.1a, 1.1.1b, etc
     # openssl >=1.1.1,<1.1.2.0a0 -> >=1.1.1a,<1.1.2a
     replace_dep(depends, "openssl >=1.1.1,<1.1.2.0a0", "openssl >=1.1.1a,<1.1.2a")
 
     # openssl3 preventive measures
     replace_dep(depends, "openssl !=1.1.1e", "openssl !=1.1.1e,<1.1.2a")
+    replace_dep(constrains, "openssl !=1.1.1e", "openssl !=1.1.1e,<1.1.2a")
     replace_dep(constrains, "openssl >=1.1.1k", "openssl >=1.1.1k,<1.1.2a")
     if name != "_anaconda_depends":
         replace_dep(depends, "openssl", "openssl<1.1.2a")

--- a/main.py
+++ b/main.py
@@ -895,6 +895,7 @@ def patch_record_in_place(fn, record, subdir):
 
     # openssl3 preventive measures
     replace_dep(depends, "openssl !=1.1.1e", "openssl !=1.1.1e,<1.1.2a")
+    replace_dep(constrains, "openssl >=1.1.1k", "openssl >=1.1.1k,<1.1.2a")
     if name != "_anaconda_depends":
         replace_dep(depends, "openssl", "openssl<1.1.2a")
 


### PR DESCRIPTION
- Adding in anything that does not have an upper bound on openssl
- Skipping _anaconda_depends as it is a meta package.