### PR TITLE
`conda-content-trust` is incompatible with `cryptography=41.0.0`

### DIFF
--- a/main.py
+++ b/main.py
@@ -918,6 +918,9 @@ def patch_record_in_place(fn, record, subdir):
         if version.startswith('2.4.0'):  # = 2.4.0*
             replace_dep(depends, ['conda', 'conda !=22.11.*'], 'conda <23.5.0,!=22.11.*')
 
+    if name == "conda-content-trust" and version == "0.1.3":
+        replace_dep(depends, "cryptography", "cryptography <41.0.0")
+
     ########################
     # run_exports mis-pins #
     ########################

--- a/main.py
+++ b/main.py
@@ -919,8 +919,7 @@ def patch_record_in_place(fn, record, subdir):
             replace_dep(depends, ['conda', 'conda !=22.11.*'], 'conda <23.5.0,!=22.11.*')
 
     if name == "conda-content-trust" and version == "0.1.3":
-        replace_dep(depends, "cryptography", "cryptography <41.0.0")
-
+        replace_dep(depends, "cryptography", "cryptography <41.0.0a0")
     ########################
     # run_exports mis-pins #
     ########################


### PR DESCRIPTION
Cryptography 41.0.0 is not available on defaults yet so this is a preemptive hotfix.

Xref https://github.com/conda/conda-content-trust/issues/56
Xref https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/462
