### PR TITLE
AC-165: urllib3 constrained for existing anaconda-client releases

### DIFF
--- a/main.py
+++ b/main.py
@@ -908,6 +908,11 @@ def patch_record_in_place(fn, record, subdir):
     ):
         depends.append("_low_priority")
 
+    if name == 'anaconda-client':
+        if re.match(r'1\.(?:\d|1[01])\.', version):  # < 1.12.0
+            if replace_dep(depends, 'urllib3 >=1.26.4', 'urllib3 >=1.26.4,<2.0.0a') == '=':  # if no changes
+                depends.append('urllib3 <2.0.0a')
+
     if name == 'anaconda-navigator':
         if re.match(r'1\.|2\.[0-2]\.', version):  # < 2.3.0
             replace_dep(depends, ['pyqt >=5.6,<6.0a0', 'pyqt >=5.6', 'pyqt'], 'pyqt >=5.6,<5.15')


### PR DESCRIPTION
Added `urllib3 < 2.0.0a` constraint to all existing `anaconda-client` releases.

General commentaries:
- `anaconda-client>=1.10.0,<1.12.0` required `urllib3 >=1.26.4` which is updated to add upper bound.
- `anaconda-client<1.10.0` used `urllib3` via `requests`. There was no explicit requirement added to the repodata, but which is now added by this hotfix.
- Explicit `urllib3 <2.0.0a` for old anaconda-client releases is also needed so `conda` won't suggest one of the old `anaconda-client` releases for the environment with `urllib3 >=2.0.0a`.

The change was tested before creating this PR - all `repodata.json` files were updated with expected changes.