### PR TITLE
restrict python max version on old s3fs releases

### DIFF
--- a/main.py
+++ b/main.py
@@ -1242,6 +1242,12 @@ def patch_record_in_place(fn, record, subdir):
     if name == "snowflake-snowpark-python" and version == '0.6.0':
         replace_dep(depends, 'cloudpickle >=1.6.0', 'cloudpickle >=1.6.0,<=2.0.0')
 
+    # s3fs downgraded to the last version not requiring botocore. 
+    if name == "s3fs" and VersionOrder(version) <= VersionOrder("0.4.2"):
+        replace_dep(depends, "python", "python <3.9")
+        replace_dep(depends, "python >=3.5", "python >=3.5,<3.9")
+        replace_dep(depends, "python >=3.6", "python >=3.6,<3.9")
+
     ###########################
     # compilers and run times #
     ###########################

--- a/main.py
+++ b/main.py
@@ -1242,7 +1242,8 @@ def patch_record_in_place(fn, record, subdir):
     if name == "snowflake-snowpark-python" and version == '0.6.0':
         replace_dep(depends, 'cloudpickle >=1.6.0', 'cloudpickle >=1.6.0,<=2.0.0')
 
-    # s3fs downgraded to the last version not requiring botocore. 
+    # s3fs downgraded to the last version not requiring botocore.
+    # ref dask/dask#10397
     if name == "s3fs" and VersionOrder(version) <= VersionOrder("0.4.2"):
         replace_dep(depends, "python", "python <3.9")
         replace_dep(depends, "python >=3.5", "python >=3.5,<3.9")


### PR DESCRIPTION
From Martin Durant:
It was suggested I cross-post here:
I need some help editing repodata. Ancient versions of s3fs are being picked up, because downgrading it by many years is a fewer number of releases back that it would be to downgrade botocore a few months (which release at least once per week). The version of s3fs being picked up is the last one not to require aiobotocore and a pin on botocore. Since this release predates py3.9, it is reasonable to set the python version bound on it to < 3.9. So I would like to change:
for s3fs <= 0.4.2 on defaults and conda-forge
to python < 3.9 and whatever lower bound already exists (in practice, the lower bound might not matter, because of dependency on fsspec)
Since pip also has this problem, I might separately yank these versions from <=2020 from pypi too. The problem is not as severe for pip, because people seem to be happier to pin versions, and generally have less "kitchen sink" envvironments.