### PR TITLE
prevent cross-installs of anaconda-ident<0.2 and anaconda-anon-usage<0.4

### DIFF
--- a/main.py
+++ b/main.py
@@ -1293,7 +1293,7 @@ def patch_record_in_place(fn, record, subdir):
     if name == "anaconda-ident" and VersionOrder(version) < VersionOrder("0.2"):
         record["constrains"] = ["anaconda-anon-usage <0"]
     if name == "anaconda-anon-usage" and VersionOrder(version) < VersionOrder("0.4"):
-        record["constrains"] = ["anaconda-ident<0"]
+        record["constrains"] = ["anaconda-ident <0"]
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -1291,7 +1291,7 @@ def patch_record_in_place(fn, record, subdir):
     # anaconda-ident<0.2 not compatible with anaconda-anon-usage
     # anaconda-anon-usage<0.4 not compatible with anaconda-ident
     if name == "anaconda-ident" and VersionOrder(version) < VersionOrder("0.2"):
-        record["constrains"] = ["anaconda-anon-usage<0"]
+        record["constrains"] = ["anaconda-anon-usage <0"]
     if name == "anaconda-anon-usage" and VersionOrder(version) < VersionOrder("0.4"):
         record["constrains"] = ["anaconda-ident<0"]
 

--- a/main.py
+++ b/main.py
@@ -1288,6 +1288,13 @@ def patch_record_in_place(fn, record, subdir):
     if name == "ffmpeg" and version == "4.2.2":
         depends[:] = [d for d in depends if not d.startswith("openssl")]
 
+    # anaconda-ident<0.2 not compatible with anaconda-anon-usage
+    # anaconda-anon-usage<0.4 not compatible with anaconda-ident
+    if name == "anaconda-ident" and VersionOrder(version) < VersionOrder("0.2"):
+        record["constrains"] = ["anaconda-anon-usage<0"]
+    if name == "anaconda-anon-usage" and VersionOrder(version) < VersionOrder("0.4"):
+        record["constrains"] = ["anaconda-ident<0"]
+
     ###########################
     # compilers and run times #
     ###########################


### PR DESCRIPTION
anaconda-ident<0.2 is not compatible with anaconda-anon-usage (any version)
anaconda-anon-usage<0.4 is not compatible with anaconda-ident (any version)

We will soon be releasing a version of anaconda-ident that depends on a version range of anaconda-anon-usage, so it's important that we avoid scenarios where they might be downgraded together. 