### PR TITLE
Pin holoviz packages to param<2

### DIFF
--- a/main.py
+++ b/main.py
@@ -1230,32 +1230,33 @@ def patch_record_in_place(fn, record, subdir):
         datashader='0.15.2',
         geoviews='1.10.1',
     )
-    for _holoviz_pkg, _holoviz_version in _holoviz_version_mapping.items():
-        if name != _holoviz_pkg:
-            continue
-        if VersionOrder(version) > VersionOrder(_holoviz_version):
-            continue
-        for i, dep in enumerate(depends):
-            if not dep.startswith("param"):
+    if name in _holoviz_version_mapping:
+        for _holoviz_pkg, _holoviz_version in _holoviz_version_mapping.items():
+            if name != _holoviz_pkg:
                 continue
-            if "<2" in dep:
+            if VersionOrder(version) > VersionOrder(_holoviz_version):
                 continue
-            if "," not in dep:
-                if "<=2" in dep or "<=3" in dep:
-                    # e.g. param <=2 or param <=3
-                    depends[i] = dep.split("<=")[0] + "<2.0.0a0"
-                elif "<" in dep:
-                    # e.g. param <3
-                    depends[i] = dep.split("<")[0] + "<2.0.0a0"
-                elif ">" not in dep:
-                    # e.g. param
-                    depends[i] = dep + " <2.0.0a0"
-                elif ">" in dep:
-                    # e.g. param >1 or param >=1
-                    depends[i] = dep + ",<2.0.0a0"
-            else:
-                # e.g. param >1,<3
-                depends[i] = dep.split(",")[0] + ",<2.0.0a0"
+            for i, dep in enumerate(depends):
+                if not dep.startswith("param"):
+                    continue
+                if "<2" in dep:
+                    continue
+                if "," not in dep:
+                    if "<=2" in dep or "<=3" in dep:
+                        # e.g. param <=2 or param <=3
+                        depends[i] = dep.split("<=")[0] + "<2.0.0a0"
+                    elif "<" in dep:
+                        # e.g. param <3
+                        depends[i] = dep.split("<")[0] + "<2.0.0a0"
+                    elif ">" not in dep:
+                        # e.g. param
+                        depends[i] = dep + " <2.0.0a0"
+                    elif ">" in dep:
+                        # e.g. param >1 or param >=1
+                        depends[i] = dep + ",<2.0.0a0"
+                else:
+                    # e.g. param >1,<3
+                    depends[i] = dep.split(",")[0] + ",<2.0.0a0"
 
     # distributed requires `dask-core`, not `dask`. This requirement also
     # became much stricter with the upstream 2021.5.0 release.


### PR DESCRIPTION
[Param 2](https://github.com/holoviz/param) is going to be released in the next few days. Param is a foundational library of the [HoloViz ecosystem](https://holoviz.org) and is going through a major release, it comes with breaking changes that can result in a very bad experience if Param 2 is installed with versions not supporting it, as Param's machinery is exerted on class creation and if it fails leads to errors on import.

This PR aims to patch all the HoloViz packages depending on Param to pin them to `param <2`. Ideally, and if this PR is approved of course, it would be merged before Param 2 is released to make sure that users don't create environments with older and incompatible HoloViz packages and Param 2. The next releases of these packages will pin `param >=2,<3`.

A similar undertaking has been already merged on conda-forge https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/565.

<details>
<summary>`python test-hotfix.py main --subdir linux-64 noarch --show-pkgs --use-cache`</summary>

```
Creating channel directory structure for channel 'main' and platforms ['linux-64', 'noarch']
Applying url to alias main. channel_base_url='https://repo.anaconda.com/pkgs/main'
Using cache for linux-64 noarch.
Executing hotfix for channel 'main'.
Completed hotfix for channel 'main'.
Analyzing results...
Writing out new repodata as main/linux-64/repodata-patched.json for 'linux-64' platform.
New Hot Fixes:
linux-64::datashader-0.14.1-py310h06a4308_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.1-py310h06a4308_1.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.1-py37h06a4308_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.1-py37h06a4308_1.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.1-py38h06a4308_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.1-py38h06a4308_1.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.1-py39h06a4308_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.1-py39h06a4308_1.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.2-py310h06a4308_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.2-py37h06a4308_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.2-py38h06a4308_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.2-py39h06a4308_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
linux-64::datashader-0.14.3-py310h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.3-py37h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.3-py38h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.3-py39h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.4-py310h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.4-py310h06a4308_1.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.4-py311h06a4308_1.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.4-py37h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.4-py38h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.4-py38h06a4308_1.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.4-py39h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.14.4-py39h06a4308_1.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.0-py310h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.0-py311h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.0-py38h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.0-py39h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.1-py310h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.1-py311h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.1-py38h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.1-py39h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.2-py310h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.2-py311h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.2-py38h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.15.2-py39h06a4308_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::datashader-0.6.6-py27_0.tar.bz2
-    "param >=1.6.0",
+    "param >=1.6.0,<2.0.0a0",
linux-64::datashader-0.6.6-py27_1.tar.bz2
-    "param >=1.6.0",
+    "param >=1.6.0,<2.0.0a0",
linux-64::datashader-0.6.6-py35_0.tar.bz2
-    "param >=1.6.0",
+    "param >=1.6.0,<2.0.0a0",
linux-64::datashader-0.6.6-py35_1.tar.bz2
-    "param >=1.6.0",
+    "param >=1.6.0,<2.0.0a0",
linux-64::datashader-0.6.6-py36_0.tar.bz2
-    "param >=1.6.0",
+    "param >=1.6.0,<2.0.0a0",
linux-64::datashader-0.6.6-py36_1.tar.bz2
-    "param >=1.6.0",
+    "param >=1.6.0,<2.0.0a0",
linux-64::holoviews-1.10.0-py27_1.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.10.0-py35_1.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.10.0-py36_1.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.16.0-py310h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.0-py311h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.0-py38h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.0-py39h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.1-py310h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.1-py311h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.1-py38h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.1-py39h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.2-py310h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.2-py311h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.2-py38h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.16.2-py39h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.17.0-py310h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.17.0-py311h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.17.0-py38h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.17.0-py39h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.17.1-py310h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.17.1-py311h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.17.1-py38h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.17.1-py39h06a4308_0.tar.bz2
-    "param >=1.12.0,<3.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::holoviews-1.9.1-py27h8db4e1f_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.1-py35hd7d2f6e_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.1-py36h76d18d8_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.2-py27_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.2-py35_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.2-py36_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.4-py27_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.4-py35_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.4-py36_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.5-py27_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.5-py35_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::holoviews-1.9.5-py36_0.tar.bz2
-    "param",
+    "param <2.0.0a0",
linux-64::hvplot-0.8.3-py310h06a4308_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
linux-64::hvplot-0.8.3-py311h06a4308_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
linux-64::hvplot-0.8.3-py38h06a4308_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
linux-64::hvplot-0.8.3-py39h06a4308_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
linux-64::hvplot-0.8.4-py310h06a4308_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
linux-64::hvplot-0.8.4-py311h06a4308_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
linux-64::hvplot-0.8.4-py38h06a4308_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
linux-64::hvplot-0.8.4-py39h06a4308_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
linux-64::panel-0.13.0-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.13.0-py37h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.13.0-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.13.0-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.13.1-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.13.1-py37h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.13.1-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.13.1-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.1-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.1-py37h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.1-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.1-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.2-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.2-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.2-py37h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.2-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.2-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.3-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.3-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.3-py37h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.3-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-0.14.3-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.2-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.2-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.2-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.2-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.3-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.3-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.3-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.3-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.4-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.4-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.4-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.0.4-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.1.0-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.1.0-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.1.0-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.1.0-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.1.1-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.1.1-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.1.1-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.1.1-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.1-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.1-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.1-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.1-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.2-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.2-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.2-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.2-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.3-py310h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.3-py311h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.3-py38h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
linux-64::panel-1.2.3-py39h06a4308_0.tar.bz2
-    "param >=1.12.0",
+    "param >=1.12.0,<2.0.0a0",
Writing out new repodata as main/noarch/repodata-patched.json for 'noarch' platform.
New Hot Fixes:
noarch::datashader-0.10.0-py_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.11.0-py_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.11.1-py_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.12.1-pyhd3eb1b0_1.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.13.0-pyhd3eb1b0_1.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.6.8-py_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.6.9-py_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.7.0-py_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.8.0-py_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::datashader-0.9.0-py_0.tar.bz2
-    "param >=1.6.1",
+    "param >=1.6.1,<2.0.0a0",
noarch::panel-0.10.2-pyhd3eb1b0_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.10.3-pyhd3eb1b0_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.10.3-pyhd3eb1b0_1.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.11.2-pyhd3eb1b0_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.11.3-pyhd3eb1b0_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.12.0-pyhd3eb1b0_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.12.1-pyhd3eb1b0_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.12.6-pyhd3eb1b0_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.12.7-pyhd3eb1b0_0.tar.bz2
-    "param >=1.10.0",
+    "param >=1.10.0,<2.0.0a0",
noarch::panel-0.4.0-0.tar.bz2
-    "param >=1.8.2",
+    "param >=1.8.2,<2.0.0a0",
noarch::panel-0.5.1-0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
noarch::panel-0.6.0-h39e3cac_0.tar.bz2
-    "param >=1.9.1",
+    "param >=1.9.1,<2.0.0a0",
noarch::panel-0.6.2-h39e3cac_0.tar.bz2
-    "param >=1.9.0",
+    "param >=1.9.0,<2.0.0a0",
noarch::panel-0.6.3-0.tar.bz2
-    "param >=1.9.1",
+    "param >=1.9.1,<2.0.0a0",
noarch::panel-0.6.4-0.tar.bz2
-    "param >=1.9.1",
+    "param >=1.9.1,<2.0.0a0",
noarch::panel-0.7.0-0.tar.bz2
-    "param >=1.9.2",
+    "param >=1.9.2,<2.0.0a0",
noarch::panel-0.8.0-0.tar.bz2
-    "param >=1.9.2",
+    "param >=1.9.2,<2.0.0a0",
noarch::panel-0.9.3-py_0.tar.bz2
-    "param >=1.9.2",
+    "param >=1.9.2,<2.0.0a0",
noarch::panel-0.9.5-py_1.tar.bz2
-    "param >=1.9.3",
+    "param >=1.9.3,<2.0.0a0",
noarch::panel-0.9.6-py_0.tar.bz2
-    "param >=1.9.3",
+    "param >=1.9.3,<2.0.0a0",
noarch::panel-0.9.7-py_0.tar.bz2
-    "param >=1.9.3",
+    "param >=1.9.3,<2.0.0a0",
```

</details>