### PR TITLE
Removing py hotfix for CVE-2022-42969

### DIFF
--- a/main.py
+++ b/main.py
@@ -1323,9 +1323,9 @@ def patch_record_in_place(fn, record, subdir):
 
     # orange3 pandas 2.1 error
     if name == "orange3" and VersionOrder(version) < VersionOrder("3.36.0"):
-        replace_dep(depends,"pandas", "pandas >=1.3.0,<2")
-        replace_dep(depends,"pandas >=1.3.0", "pandas >=1.3.0,<2")
-        replace_dep(depends,"pandas >=1.3.0,!=1.5.0", "pandas >=1.3.0,!=1.5.0,<2")
+        replace_dep(depends, "pandas", "pandas >=1.3.0,<2")
+        replace_dep(depends, "pandas >=1.3.0", "pandas >=1.3.0,<2")
+        replace_dep(depends, "pandas >=1.3.0,!=1.5.0", "pandas >=1.3.0,!=1.5.0,<2")
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -671,36 +671,6 @@ def patch_record_in_place(fn, record, subdir):
                 depends[i] = depends[i].replace(">=1.21.5,", ">=1.21.2,")
                 break
 
-    ############
-    # pytest-* #
-    ############
-
-    # When we upgraded `pytest` to v7.3.1, we unknowingly broke several (if not
-    # all) `pytest-*` plugins. In v7.2.0, `pytest` removed `py` as a dependency
-    # and at least some plugins were all silently depending on it transitively
-    # from `pytest`. See here for more context:
-    # - https://github.com/pytest-dev/pytest/releases/tag/7.2.0
-    #   - "pytest no longer depends on the py library...."
-    # - https://github.com/pytest-dev/pytest-html/releases/tag/v3.2.0
-    #   - "Add py as a dependency"
-    # - https://anaconda.slack.com/archives/C03HJF22C4W/p1684253695788659
-    #   - Slack thread that dicusses this further
-    # Dropping `py` from `pytest` was likely caused by this CVE against `py`
-    # that the community (as of writing) still seems to be hashing out:
-    # - https://github.com/advisories/GHSA-w596-4wvx-j9j6
-    # To address this, we have decided to patch-in the `py` dependency for
-    # these packages for the time being. The aforementioned unresolved CVE may
-    # require us to take a different approach in the future.
-    if name.startswith("pytest-"):
-        # Prevent existing projects with `py` dependencies from being included
-        has_py = False
-        for dep in depends:
-            if re.match(r"py(<|>|=|!|~|\s|$)", dep):
-                has_py = True
-                break
-        if not has_py:
-            replace_dep(depends, "", "py", append=True)
-
     ###########
     # pytorch #
     ###########


### PR DESCRIPTION
Removing the hotfix due to it currently adding in CVE-2022-42969 into `pytest` through `py`.

CVE: https://nvd.nist.gov/vuln/detail/CVE-2022-42969

Jira Ticket: https://anaconda.atlassian.net/browse/CVE-566

CVE Curation: https://github.com/anaconda-distribution/cve-curations/pull/129/files

I `grepped` through our `pytest` plugin feedstocks to look for any `py` dependencies. In the following PR's I'm adding `py` in as a dependency instead of using the hotfix.

pytest-benchmark-feedstock: https://github.com/AnacondaRecipes/pytest-benchmark-feedstock/pull/3
pytest-cov-feedstock: https://github.com/AnacondaRecipes/pytest-cov-feedstock/pull/5
pytest-csv-feedstock: https://github.com/AnacondaRecipes/pytest-csv-feedstock/pull/1
pytest-flake8-feedstock: https://github.com/AnacondaRecipes/pytest-flake8-feedstock/pull/1
pytest-forked-feedstock: https://github.com/AnacondaRecipes/pytest-forked-feedstock/pull/2
pytest-mpi-feedstock: https://github.com/AnacondaRecipes/pytest-mpi-feedstock/pull/1
pytest-rerunfailures-feedstock: https://github.com/AnacondaRecipes/pytest-rerunfailures-feedstock/pull/3