### PR TITLE
Require menuinst 2 in conda-build

### DIFF
--- a/main.py
+++ b/main.py
@@ -875,6 +875,11 @@ def patch_record_in_place(fn, record, subdir):
                     dep_name, other[0] + "," if other else ""
                 )
 
+            # Avoid issue on Windows where an old menuinst 1.x is allowed in the environment
+            # and breaks the JSON validation with a failed import
+            if  dep_name == "menuinst" and VersionOrder(version) <= VersionOrder("3.28.1"):
+                depends[i] = "menuinst >=2.0.1"
+
     if name == "constructor":
         if int(version[0]) < 3:
             replace_dep(depends, "conda", "conda <4.6.0a0")

--- a/main.py
+++ b/main.py
@@ -877,7 +877,7 @@ def patch_record_in_place(fn, record, subdir):
 
             # Avoid issue on Windows where an old menuinst 1.x is allowed in the environment
             # and breaks the JSON validation with a failed import
-            if  dep_name == "menuinst" and VersionOrder(version) <= VersionOrder("3.28.1"):
+            if dep_name == "menuinst" and VersionOrder(version) <= VersionOrder("3.28.1"):
                 depends[i] = "menuinst >=2.0.1"
 
     if name == "constructor":


### PR DESCRIPTION
conda-build 3.28.x

**Destination channel:** defaults

### Links

- [{ticket_number}](#N/A) 
- [Upstream repository](https://github.com/conda/conda-build)
- [Upstream changelog/diff](#N/A)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- conda-build 3.28 validates menuinst v2 files if detected in the $PREFIX. To do so it imports `menuinst`'s schema and runs `jsonschema` with it.
- On Unix, the only menuinst available is v2, but on Windows v1 is also around. There's a combination of conda, conda-build and menuinst versions that results in a broken import (`ImportError: cannot import name 'data_path' from 'menuinst.utils'`) because conda-build does not require v2 in its metadata.
