### PR TITLE
restrict nb_conda to notebook<7

### DIFF
--- a/main.py
+++ b/main.py
@@ -1046,6 +1046,12 @@ def patch_record_in_place(fn, record, subdir):
             replace_dep(depends, "jupyter_client >=5.2.0", "jupyter_client >=5.2.0,<8")
             replace_dep(depends, "jupyter_client", "jupyter_client <8")
 
+    # no cross-compatibility possible between Notebook 6 and 7 extensions
+    if name == "nb_conda" and VersionOrder(version) <= VersionOrder("2.2.1"):
+        replace_dep(depends, "notebook >=4.3.1", "notebook >=4.3.1,<7")
+    if name == "nb_conda_kernels" and VersionOrder(version) <= VersionOrder("2.3.1"):
+        replace_dep(depends, "notebook >=4.2.0", "notebook >=4.2.0,<7")
+
     # requests-toolbelt<1.0.0 does not support urllib3>=2.0.0 (which is an indirect dependency)
     # issue: https://github.com/Anaconda-Platform/anaconda-client/issues/654#issuecomment-1655089483
     if (name == 'requests-toolbelt') and version.startswith('0.'):


### PR DESCRIPTION
Notebook 7.0 has changed the way it does extensions, so the post-install scripts won't work.  And probably the extension even if install worked. This will affect everyone that want to easily find and switch conda environments in JupyterNotebooks with nb_conda.