### PR TITLE
Pin conda to less than 24.3.0 on conda-build > 3.21.8 and <24.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup environment
         shell: bash -l {0}
         run: |
-          conda create --name testenv conda conda-build flake8 requests
+          conda create --name testenv conda conda-index flake8 requests
       - name: Lint
         shell: bash -l {0}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ help:
 
 init:
 	@if [ -z "$${CONDA_SHLVL:+x}" ]; then echo "Conda is not installed." && exit 1; fi
-	@conda create -y -n repodata-hotfixes conda conda-build flake8 pytest requests
+	@conda create -y -n repodata-hotfixes conda conda-index flake8 pytest requests
 
 check: lint test
 

--- a/gen-current-hotfix-report.py
+++ b/gen-current-hotfix-report.py
@@ -28,7 +28,7 @@ from collections import defaultdict
 from pathlib import Path
 
 from conda.exports import subdir as conda_subdir
-from conda_build.index import _apply_instructions
+from conda_index.index import _apply_instructions
 
 channel_map = {
     "main": "https://repo.anaconda.com/pkgs/main",

--- a/main.py
+++ b/main.py
@@ -877,7 +877,11 @@ def patch_record_in_place(fn, record, subdir):
 
             # Deprecations removed in conda 24.3.0 break conda-build <24.3.0.
             # Note that we don't want to affect conda-build <=3.21.8
-            if dep_name == "conda" and VersionOrder(version) > VersionOrder("3.21.8") and VersionOrder(version) < VersionOrder("24.3.0"):
+            if (
+                dep_name == "conda" and
+                VersionOrder(version) > VersionOrder("3.21.8") and
+                VersionOrder(version) < VersionOrder("24.3.0")
+            ):
                 depends[i] = "{} {}<24.3.0".format(
                     dep_name, other[0] + "," if other else ""
                 )

--- a/main.py
+++ b/main.py
@@ -875,6 +875,13 @@ def patch_record_in_place(fn, record, subdir):
                     dep_name, other[0] + "," if other else ""
                 )
 
+            # Deprecations removed in conda 24.3.0 break conda-build <24.3.0.
+            # Note that we don't want to affect conda-build <=3.21.8
+            if dep_name == "conda" and VersionOrder(version) > VersionOrder("3.21.8") and VersionOrder(version) < VersionOrder("24.3.0"):
+                depends[i] = "{} {}<24.3.0".format(
+                    dep_name, other[0] + "," if other else ""
+                )
+
             # Avoid issue on Windows where an old menuinst 1.x is allowed in the environment
             # and breaks the JSON validation with a failed import
             if dep_name == "menuinst" and VersionOrder(version) <= VersionOrder("3.28.1"):

--- a/test-hotfix.py
+++ b/test-hotfix.py
@@ -4,7 +4,7 @@ import os
 import subprocess
 
 from conda.exports import subdir as conda_subdir
-from conda_build.index import _apply_instructions
+from conda_index.index import _apply_instructions
 import urllib
 
 html_differ = difflib.HtmlDiff()


### PR DESCRIPTION
It was reported that conda 24.3.0 breaks conda-build. This PR adds `<24.3.0` as a constraint to the conda dependency on conda-build > 3.21.8 and <24.3.0.