### PR TITLE
NAVI-159: remove broken navigator-updater

### DIFF
--- a/main.py
+++ b/main.py
@@ -101,6 +101,8 @@ REMOVALS = {
         "numpy-devel-1.14.3*",
         # anaconda-client<1.10.0 is incompatible with python 3.10
         "anaconda-client-1.9.0-py310*",
+        # navigator-updater=0.5.0 is incompatible with anaconda-navigator
+        "navigator-updater-0.5.0-*"
     },
 }
 


### PR DESCRIPTION
Remove `navigator-updater=0.5.0` from `defaults`.

This version is broken (_can not be launched from "Update available" dialog in Anaconda Navigator_).

Should be merged after the `navigator-updater=0.5.1` release.