### PR TITLE
Remove old shortcuts from navigator

### DIFF
--- a/main.py
+++ b/main.py
@@ -512,6 +512,8 @@ def patch_record(fn, record, subdir, instructions, index):
     original_record = copy.deepcopy(record)
     patch_record_in_place(fn, record, subdir)
     keys_to_check = [
+        "app_entry",
+        "app_type",
         "constrains",
         "depends",
         "features",
@@ -519,6 +521,7 @@ def patch_record(fn, record, subdir, instructions, index):
         "license_family",
         "subdir",
         "track_features",
+        "type",
     ]
     for key in keys_to_check:
         if record.get(key) != original_record.get(key):
@@ -845,6 +848,15 @@ def patch_record_in_place(fn, record, subdir):
     #############################################
     # anaconda, conda, conda-build, constructor #
     #############################################
+
+    # Remove old shortcut packages from Navigator panel
+    if name.startswith("console_shortcut") or name.startswith("powershell_shortcut"):
+        if "app_entry" in record:
+            del record["app_entry"]
+        if "app_type" in record:
+            del record["app_type"]
+        if record.get("type") == "app":
+            del record["type"]
 
     if (
         name == "anaconda"

--- a/main.py
+++ b/main.py
@@ -850,7 +850,12 @@ def patch_record_in_place(fn, record, subdir):
     #############################################
 
     # Remove old shortcut packages from Navigator panel
-    if name in ["console_shortcut", "console_shortcut_miniconda", "powershell_shortcut", "powershell_shortcut_miniconda"]:
+    if name in [
+        "console_shortcut",
+        "console_shortcut_miniconda",
+        "powershell_shortcut",
+        "powershell_shortcut_miniconda",
+    ]:
         if "app_entry" in record:
             del record["app_entry"]
         if "app_type" in record:

--- a/main.py
+++ b/main.py
@@ -850,7 +850,7 @@ def patch_record_in_place(fn, record, subdir):
     #############################################
 
     # Remove old shortcut packages from Navigator panel
-    if name.startswith("console_shortcut") or name.startswith("powershell_shortcut"):
+    if name in ["console_shortcut", "console_shortcut_miniconda", "powershell_shortcut", "powershell_shortcut_miniconda"]:
         if "app_entry" in record:
             del record["app_entry"]
         if "app_type" in record:


### PR DESCRIPTION
There are currently four `console_shortcut` feedstocks, two for Anaconda and two for Miniconda. This results in four panels in Anaconda Navigator, two of which are redundant. They will soon be consolidated into another feedstock, which would result in six panels.

This hotfix avoids this by removing the data from the recipe. It additionally fixes the problem with redundant panels and also removes the panels of unsupported platforms that had been built in the past.

This will not affect panels where the old `console_shortcut` package has been installed. They will stay until uninstalled.

Hotfix output: [output.txt](https://github.com/user-attachments/files/15878276/output.txt)
