### PR TITLE
Revoke menuinst2

### DIFF
--- a/main.py
+++ b/main.py
@@ -142,8 +142,8 @@ REVOKED = {
         # and uninstallers to break under certain circumstances.
         "anaconda-navigator-2.6.0-*_1.*",
         "anaconda-navigator-2.6.1-*_1.*",
-        "git-2.40.1-haa95532_2.*",
-        "git-2.40.1-haa95532_3.*",
+        "git-2.40.1-*_2.*",
+        "git-2.40.1-*_3.*",
         "notebook-7.0.8-*_1.*",
         "spyder-5.5.1-*_1.*",
         "spyder-5.5.1-*_2.*",

--- a/main.py
+++ b/main.py
@@ -136,6 +136,8 @@ REVOKED = {
     ],
     "win-64": [
         "spyder-kernels-1.0.1-*_0",
+    ],
+    "any": [
         # Packages with bad shortcuts that can cause installers
         # and uninstallers to break under certain circumstances.
         "anaconda-navigator-2.6.0-*_1.*",
@@ -146,7 +148,6 @@ REVOKED = {
         "spyder-5.5.1-*_1.*",
         "spyder-5.5.1-*_2.*",
     ],
-    "any": [],
 }
 
 # This is a list of numpy-base packages for each subdir which multiple numpy

--- a/main.py
+++ b/main.py
@@ -136,6 +136,15 @@ REVOKED = {
     ],
     "win-64": [
         "spyder-kernels-1.0.1-*_0",
+        # Packages with bad shortcuts that can cause installers
+        # and uninstallers to break under certain circumstances.
+        "anaconda-navigator-2.6.0-*_1.*",
+        "anaconda-navigator-2.6.1-*_1.*",
+        "git-2.40.1-haa95532_2.*",
+        "git-2.40.1-haa95532_3.*",
+        "notebook-7.0.8-*_1.*",
+        "spyder-5.5.1-*_1.*",
+        "spyder-5.5.1-*_2.*",
     ],
     "any": [],
 }


### PR DESCRIPTION
The current integration of menuinst2 is causing issues with installers and uninstallers and thus have to be reverted. This hotfix revokes the currently broken packages so that they don't appear in solvers.

Output of test-hotfixes: [hotfix.log](https://github.com/user-attachments/files/15980426/hotfix.log)