### PR TITLE
Add async-timeout to ray-core

### DIFF
--- a/main.py
+++ b/main.py
@@ -1400,10 +1400,11 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "pandas", "pandas >=1.3.0,<2")
         replace_dep(depends, "pandas >=1.3.0", "pandas >=1.3.0,<2")
         replace_dep(depends, "pandas >=1.3.0,!=1.5.0", "pandas >=1.3.0,!=1.5.0,<2")
-    
+
     # ray-core needs async-timeout
-    if name == "ray-core" and VersionOrder(version) < VersionOrder("2.6.4") and not any(_.startswith("async-timeout") for _ in depends):
-        depends.append("async-timeout")
+    if name == "ray-core" and VersionOrder(version) < VersionOrder("2.6.4"): 
+        if not any(_.startswith("async-timeout") for _ in depends):
+            depends.append("async-timeout")
 
     ###########################
     # compilers and run times #

--- a/main.py
+++ b/main.py
@@ -1402,7 +1402,7 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "pandas >=1.3.0,!=1.5.0", "pandas >=1.3.0,!=1.5.0,<2")
     
     # ray-core needs async-timeout
-    if name == "ray-core" and VersionOrder(version) < VersionOrder("2.6.4"):
+    if name == "ray-core" and VersionOrder(version) < VersionOrder("2.6.4") and not any(_.startswith("async-timeout") for _ in depends):
         depends.append("async-timeout")
 
     ###########################

--- a/main.py
+++ b/main.py
@@ -1402,7 +1402,7 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "pandas >=1.3.0,!=1.5.0", "pandas >=1.3.0,!=1.5.0,<2")
 
     # ray-core needs async-timeout
-    if name == "ray-core" and VersionOrder(version) < VersionOrder("2.6.4"): 
+    if name == "ray-core" and VersionOrder(version) < VersionOrder("2.6.4"):
         if not any(_.startswith("async-timeout") for _ in depends):
             depends.append("async-timeout")
 

--- a/main.py
+++ b/main.py
@@ -1400,6 +1400,10 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "pandas", "pandas >=1.3.0,<2")
         replace_dep(depends, "pandas >=1.3.0", "pandas >=1.3.0,<2")
         replace_dep(depends, "pandas >=1.3.0,!=1.5.0", "pandas >=1.3.0,!=1.5.0,<2")
+    
+    # ray-core needs async-timeout
+    if name == "ray-core" and VersionOrder(version) < VersionOrder("2.6.4"):
+        depends.append("async-timeout")
 
     ###########################
     # compilers and run times #


### PR DESCRIPTION

### Links

- [PKG-5500]
- [test-hotfix.py output](https://github.com/user-attachments/files/16554007/test-hotfix-output.txt)

### Explanation of changes:

- Per [this issue](https://github.com/ray-project/ray/issues/41267), `ray` depends on `async-timeout`, but has relied on `aiohttp` to provide it. Since`aiohttp` no longer requires `async-timeout`, it's necessary to add it to `ray`.
- I've confirmed that `async-timeout` has been imported since at least `ray` 1.0, and therefore applies to all versions present on main.


[PKG-5500]: https://anaconda.atlassian.net/browse/PKG-5500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ