### PR TITLE
Hypothesis hotfix exclusion

### DIFF
--- a/generate_numpy2_patch.py
+++ b/generate_numpy2_patch.py
@@ -8,7 +8,7 @@ from pathlib import Path
 numpy2_protect_dict = {
     # add any numpy dependencies that needs to be protected here
     # "package_name": "protected_version"
-    "hypothesis": "6.100.1"
+    "hypothesis": "6.111.0"
 }
 
 proposed_changes = []

--- a/generate_numpy2_patch.py
+++ b/generate_numpy2_patch.py
@@ -4,7 +4,6 @@ import json
 import re
 from collections import defaultdict
 from pathlib import Path
-from conda.models.version import VersionOrder
 
 numpy2_protect_dict = {
     # add any numpy dependencies that needs to be protected here
@@ -131,7 +130,8 @@ def update_numpy_dependencies(dependencies_list, package_record, dependency_type
 
         # Check if the dependency is for numpy and does not have an upper bound
         if "numpy" in package_name and not has_upper_bound(dependency):
-            if package_record["name"] in numpy2_protect_dict and package_record["version"] == numpy2_protect_dict.get(package_record["name"], None):
+            if package_record["name"] in numpy2_protect_dict and \
+               package_record["version"] == numpy2_protect_dict.get(package_record["name"], None):
                 # Handle dependencies that are in the protection dictionary
                 logger.info(f"numpy 2.0.0: {package_record['name']} is protected at {package_record['version']}")
             elif add_bound_to_unspecified:

--- a/numpy2_patch.json
+++ b/numpy2_patch.json
@@ -1765,26 +1765,6 @@
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
     },
-    "hypothesis-6.100.1-py310h06a4308_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py311h06a4308_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py312h06a4308_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py39h06a4308_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
     "hypothesis-6.82.0-py310h06a4308_0.tar.bz2": {
       "type": "constrains",
       "original": "numpy >=1.17.3",
@@ -6712,26 +6692,6 @@
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
     },
-    "hypothesis-6.100.1-py310hd43f75c_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py311hd43f75c_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py312hd43f75c_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py39hd43f75c_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
     "hypothesis-6.82.0-py310hd43f75c_0.tar.bz2": {
       "type": "constrains",
       "original": "numpy >=1.17.3",
@@ -10559,26 +10519,6 @@
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
     },
-    "hypothesis-6.100.1-py310ha847dfd_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py311ha847dfd_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py312ha847dfd_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py39ha847dfd_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
     "hypothesis-6.82.0-py310ha847dfd_0.tar.bz2": {
       "type": "constrains",
       "original": "numpy >=1.17.3",
@@ -14155,26 +14095,6 @@
       "type": "depends",
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
-    },
-    "hypothesis-6.100.1-py310hecd8cb5_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py311hecd8cb5_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py312hecd8cb5_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py39hecd8cb5_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
     },
     "hypothesis-6.82.0-py310hecd8cb5_0.tar.bz2": {
       "type": "constrains",
@@ -19058,26 +18978,6 @@
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
     },
-    "hypothesis-6.100.1-py310hca03da5_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py311hca03da5_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py312hca03da5_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py39hca03da5_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
     "hypothesis-6.82.0-py310hca03da5_0.tar.bz2": {
       "type": "constrains",
       "original": "numpy >=1.17.3",
@@ -23884,26 +23784,6 @@
       "type": "depends",
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
-    },
-    "hypothesis-6.100.1-py310haa95532_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py311haa95532_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py312haa95532_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
-    },
-    "hypothesis-6.100.1-py39haa95532_0.tar.bz2": {
-      "type": "constrains",
-      "original": "numpy >=1.17.3",
-      "updated": "numpy >=1.17.3,<2.0a0"
     },
     "hypothesis-6.82.0-py310haa95532_0.tar.bz2": {
       "type": "constrains",

--- a/numpy2_patch.json
+++ b/numpy2_patch.json
@@ -1765,6 +1765,26 @@
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
     },
+    "hypothesis-6.100.1-py310h06a4308_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py311h06a4308_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py312h06a4308_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py39h06a4308_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
     "hypothesis-6.82.0-py310h06a4308_0.tar.bz2": {
       "type": "constrains",
       "original": "numpy >=1.17.3",
@@ -6692,6 +6712,26 @@
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
     },
+    "hypothesis-6.100.1-py310hd43f75c_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py311hd43f75c_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py312hd43f75c_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py39hd43f75c_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
     "hypothesis-6.82.0-py310hd43f75c_0.tar.bz2": {
       "type": "constrains",
       "original": "numpy >=1.17.3",
@@ -10519,6 +10559,26 @@
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
     },
+    "hypothesis-6.100.1-py310ha847dfd_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py311ha847dfd_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py312ha847dfd_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py39ha847dfd_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
     "hypothesis-6.82.0-py310ha847dfd_0.tar.bz2": {
       "type": "constrains",
       "original": "numpy >=1.17.3",
@@ -14095,6 +14155,26 @@
       "type": "depends",
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
+    },
+    "hypothesis-6.100.1-py310hecd8cb5_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py311hecd8cb5_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py312hecd8cb5_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py39hecd8cb5_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
     },
     "hypothesis-6.82.0-py310hecd8cb5_0.tar.bz2": {
       "type": "constrains",
@@ -18978,6 +19058,26 @@
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
     },
+    "hypothesis-6.100.1-py310hca03da5_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py311hca03da5_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py312hca03da5_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py39hca03da5_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
     "hypothesis-6.82.0-py310hca03da5_0.tar.bz2": {
       "type": "constrains",
       "original": "numpy >=1.17.3",
@@ -23784,6 +23884,26 @@
       "type": "depends",
       "original": "numpy >=1.15",
       "updated": "numpy >=1.15,<2.0a0"
+    },
+    "hypothesis-6.100.1-py310haa95532_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py311haa95532_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py312haa95532_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
+    },
+    "hypothesis-6.100.1-py39haa95532_0.tar.bz2": {
+      "type": "constrains",
+      "original": "numpy >=1.17.3",
+      "updated": "numpy >=1.17.3,<2.0a0"
     },
     "hypothesis-6.82.0-py310haa95532_0.tar.bz2": {
       "type": "constrains",


### PR DESCRIPTION
-	Corrected the NumPy2 hotfix: Adjusted the hotfix to allow specific patches to be excluded, providing more control over which patches are applied.
-       Created the logic for hypothesis 6.111.0 to not be affected by this script 
