### PR TITLE
Basemap uninstall fix.

### DIFF
--- a/main.py
+++ b/main.py
@@ -847,7 +847,8 @@ def patch_record_in_place(fn, record, subdir):
 
     # basemap is incompatible with proj/proj4 >=6
     # https://github.com/ContinuumIO/anaconda-issues/issues/11590
-    if name == "basemap" and VersionOrder(version) <= VersionOrder("1.2.0"):
+    # Adding update to constraint to capture data reorg in the project.
+    if name == "basemap" and VersionOrder(version) < VersionOrder("1.3.0"):
         record["constrains"] = ["proj4 <6", "proj <6"]
 
     # 'cryptography' + pyopenssl incompatibility 28 Feb 2023 #

--- a/main.py
+++ b/main.py
@@ -847,7 +847,7 @@ def patch_record_in_place(fn, record, subdir):
 
     # basemap is incompatible with proj/proj4 >=6
     # https://github.com/ContinuumIO/anaconda-issues/issues/11590
-    if name == "basemap":
+    if name == "basemap" and VersionOrder(version) <= VersionOrder("1.2.0"):
         record["constrains"] = ["proj4 <6", "proj <6"]
 
     # 'cryptography' + pyopenssl incompatibility 28 Feb 2023 #


### PR DESCRIPTION
Creating an upper bound on basemap constraint.

Currently trying to install it yields:
```
conda create --dry-run -n bm_test basemap
Channels:
 - defaults
Platform: osx-arm64
Collecting package metadata (repodata.json): done
Solving environment: failed

LibMambaUnsatisfiableError: Encountered problems while solving:
  - package basemap-1.2.2-py38hd91d049_1 requires proj >=7.2.0,<7.2.1.0a0, but none of the providers can be installed

Could not solve for environment specs
The following packages are incompatible
└─ basemap is installable with the potential options
   ├─ basemap 1.2.2 would require
   │  └─ proj [<6 |>=7.2.0,<7.2.1.0a0 ] with the potential options
   │     ├─ proj 7.2.0, which can be installed;
   │     └─ proj <6 conflicts with any installable versions previously reported;
   ├─ basemap 1.2.2 would require
   │  └─ proj [ |<6 ] with the potential options
   │     ├─ proj 7.2.0, which can be installed;
   │     ├─ proj 6.2.1, which can be installed;
   │     ├─ proj 8.2.1, which can be installed;
   │     ├─ proj 9.3.1, which can be installed;
   │     └─ proj <6 conflicts with any installable versions previously reported;
   ├─ basemap [1.3.2|1.3.6] would require
   │  ├─ proj <6 , which conflicts with any installable versions previously reported;
   │  └─ pyproj [>=1.9.3,<3.4 |>=1.9.3,<3.5.0 ] with the potential options
   │     ├─ pyproj 3.1.0 would require
   │     │  └─ proj >=7.2.0,<7.2.1.0a0 , which can be installed;
   │     └─ pyproj [3.3.0|3.4.1] would require
   │        └─ proj >=8.2.1,<8.2.2.0a0 , which can be installed;
   └─ basemap 1.4.0 would require
      ├─ proj <6 , which conflicts with any installable versions previously reported;
      └─ pyproj >=1.9.3,<3.7.0  with the potential options
         ├─ pyproj 3.1.0, which can be installed (as previously explained);
         ├─ pyproj [3.3.0|3.4.1], which can be installed (as previously explained);
         └─ pyproj 3.6.1 would require
            └─ proj >=9.3.1,<9.3.2.0a0 , which can be installed.
```

The note on the constraint mentions this issue https://github.com/ContinuumIO/anaconda-issues/issues/11590.  It may have been misdiagnosed.  basemap did do a small reorg in 1.3.0 where it states it put enough data to be functional.  I think this constraint should be the right place to protect the past but enable the future.