### PR TITLE
Pin `libmambapy<2` in all conda-libmamba-solver builds

### DIFF
--- a/main.py
+++ b/main.py
@@ -1390,6 +1390,10 @@ def patch_record_in_place(fn, record, subdir):
         if VersionOrder(version) < VersionOrder("24.7.0a0"):
             # https://github.com/conda/conda-libmamba-solver/pull/492
             replace_dep(depends, "libmambapy >=1.5.6", "libmambapy >=1.5.6,<2.0.0a0")
+            replace_dep(depends, "libmambapy >=1.5.3", "libmambapy >=1.5.3,<2.0.0a0")
+            replace_dep(depends, "libmambapy >=1.5.1", "libmambapy >=1.5.1,<2.0.0a0")
+            replace_dep(depends, "libmambapy >=1.4.1", "libmambapy >=1.4.1,<2.0.0a0")
+            replace_dep(depends, "libmambapy >=1.0.0", "libmambapy >=1.0.0,<2.0.0a0")
             replace_dep(depends, "libmambapy >=0.23", "libmambapy >=0.23,<2.0.0a0")
             replace_dep(depends, "libmambapy >=0.22.1", "libmambapy >=0.22.1,<2.0.0a0")
 


### PR DESCRIPTION
conda-libmamba-solver <= 24.7

**Destination channel:** defaults

### Links

- [{ticket_number}]() 
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- Some conda-libmamba-solver builds were not patched for libmambapy<2. This leaves an opportunity for users mixing conda-forge and defaults to upgrade to mamba v2, which would cause conda-libmamba-solver to break.
