### PR TITLE
Revoke anaconda-cli-base-0.4.1 build number 0 because of missing run_constrained

### DIFF
--- a/main.py
+++ b/main.py
@@ -147,6 +147,8 @@ REVOKED = {
         "notebook-7.0.8-*_1.*",
         "spyder-5.5.1-*_1.*",
         "spyder-5.5.1-*_2.*",
+        # anaconda-cli-base-0.4.1 build number 0 has missing run_constrained requirements
+        "anaconda-cli-base-0.4.1-*_0.*",
     ],
 }
 


### PR DESCRIPTION
### Links

- [PKG-6182](https://anaconda.atlassian.net/browse/PKG-6182) 

### Explanation of changes:

- `anaconda-cli-base 0.4.1 build number 0` doesn't have `run_constrained` to ensure that a version of `anaconda-cli-base` cannot be installed if an incompatible older version of `anaconda-client` is installed.

If you try to install `anaconda-client=1.12` with `anaconda-cloud-auth=0.7.2`:
`conda create -n dry --dry-run -c defaults --override-channels anaconda-client=1.12 anaconda-cloud-auth=0.7.2`

then **anaconda-cli-base-0.4.1-py'*'_0** will be picked up but _NOT_ **_1**. This can break many **anaconda-client** users

`run_constrained` has been added in [anaconda-cli-base 0.4.1 build number 1](https://github.com/AnacondaRecipes/anaconda-cli-base-feedstock/pull/5/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR33-R37):
```
  run_constrained:
      - anaconda-client >=1.13.0
      - anaconda-cloud-cli >=0.3.0
```

## The hotfix

- We revoke entirely "anaconda-cli-base-0.4.1-**_0.** because it's not needed.

- It was tested by running `python test-hotfix.py main --subdir linux-64 osx-64 win-64 osx-arm64 linux-aarch64 linux-s390x noarch`

The result will be like this:
```
Writing out new repodata as main/osx-arm64/repodata-patched.json for 'osx-arm64' platform.
*** main/osx-arm64/repodata-reference.json	2024-11-15 10:53:51.615281919 +0200
--- main/osx-arm64/repodata-patched.json	2024-11-15 10:54:19.960597974 +0200
***************
*** 57305,57320 ****
          "click",
          "pydantic-settings >=2.3",
          "python >=3.10,<3.11.0a0",
          "readchar",
          "rich",
!         "typer"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
        "md5": "b9bed9bd6feded65aea82db90a1be978",
        "name": "anaconda-cli-base",
        "sha256": "14bfc2bdb54e3b62feb1300db1a5434486e6414942a9a76b3f1cc67330205160",
        "size": 26956,
        "subdir": "osx-arm64",
        "timestamp": 1731423928132,
        "version": "0.4.1"
--- 57305,57322 ----
          "click",
          "pydantic-settings >=2.3",
          "python >=3.10,<3.11.0a0",
          "readchar",
          "rich",
!         "typer",
!         "package_has_been_revoked"
        ],
        "license": "BSD-3-Clause",
        "license_family": "BSD",
        "md5": "b9bed9bd6feded65aea82db90a1be978",
        "name": "anaconda-cli-base",
+       "revoked": true,
        "sha256": "14bfc2bdb54e3b62feb1300db1a5434486e6414942a9a76b3f1cc67330205160",
        "size": 26956,
        "subdir": "osx-arm64",
        "timestamp": 1731423928132,
        "version": "0.4.1"
```


[PKG-6182]: https://anaconda.atlassian.net/browse/PKG-6182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ