### PR TITLE
NAVI-279: incompatibilities with anaconda-cloud-auth

### DIFF
--- a/main.py
+++ b/main.py
@@ -951,7 +951,9 @@ def patch_record_in_place(fn, record, subdir):
                 'conda !=22.11.*,!=23.7.0,!=23.7.1,!=23.7.2,!=23.7.3',
             )
 
-    if name in ('aext-assistant-server', 'aext-shared', 'anaconda-navigator', 'anaconda-toolbox'):
+    if ((name in ('aext-assistant-server', 'aext-shared', 'anaconda-toolbox') and
+            VersionOrder(version) <= VersionOrder("4.0.15")) or
+            (name == 'anaconda-navigator' and VersionOrder(version) <= VersionOrder("2.6.3"))):
         replace_dep(depends, 'anaconda-cloud-auth', 'anaconda-cloud-auth <0.7.0')
         replace_dep(depends, 'anaconda-cloud-auth >=0.1.3', 'anaconda-cloud-auth >=0.1.3,<0.7.0')
         replace_dep(depends, 'anaconda-cloud-auth >=0.4.1', 'anaconda-cloud-auth >=0.4.1,<0.7.0')

--- a/main.py
+++ b/main.py
@@ -951,6 +951,11 @@ def patch_record_in_place(fn, record, subdir):
                 'conda !=22.11.*,!=23.7.0,!=23.7.1,!=23.7.2,!=23.7.3',
             )
 
+    if name in ('aext-assistant-server', 'aext-shared', 'anaconda-navigator', 'anaconda-toolbox'):
+        replace_dep(depends, 'anaconda-cloud-auth', 'anaconda-cloud-auth <0.7.0')
+        replace_dep(depends, 'anaconda-cloud-auth >=0.1.3', 'anaconda-cloud-auth >=0.1.3,<0.7.0')
+        replace_dep(depends, 'anaconda-cloud-auth >=0.4.1', 'anaconda-cloud-auth >=0.4.1,<0.7.0')
+
     if name == "conda-content-trust" and VersionOrder(version) <= VersionOrder("0.1.3"):
         replace_dep(depends, "cryptography", "cryptography <41.0.0a0")
 


### PR DESCRIPTION
**Destination channel:** defaults

### Explanation of changes:

`anaconda-cloud-auth` in `0.7.0+` introduced changes that are incompatible with previous releases. Those changes affected multiple of our products (_`anaconda-navigator` and `anaconda-toolbox` in this PR in particular_). To mitigate the issue - we are adding upper boundaries to forbid installing incompatible apps and libraries together.

_P.S. all new navigator and toolbox releases already have dependency set to the ` anaconda-cloud-auth>=0.7.1` so they should not be affected when they release_
