### PR TITLE
handle libarchive 3.7.5

### DIFF
--- a/main.py
+++ b/main.py
@@ -1470,7 +1470,8 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "poppler", "poppler <=22.12.0")
 
     # libarchive 3.7.5 abi breaking change - https://github.com/libarchive/libarchive/pull/1976
-    if name == "libmamba" and VersionOrder(version) >= VersionOrder("1.5.8") and VersionOrder(version) <= VersionOrder("1.5.11"):
+    if (name == "libmamba" and VersionOrder(version) >= VersionOrder("1.5.8") and
+            VersionOrder(version) <= VersionOrder("1.5.11")):
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
     if name == "tesseract" and version == "5.2.0":
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")

--- a/main.py
+++ b/main.py
@@ -1470,7 +1470,7 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "poppler", "poppler <=22.12.0")
 
     # libarchive 3.7.5 abi breaking change - https://github.com/libarchive/libarchive/pull/1976
-    if name == "libmamba" and VersionOrder(version) >= VersionOrder("1.5.8") and VersionOrder(version) >= VersionOrder("1.5.11"):
+    if name == "libmamba" and VersionOrder(version) >= VersionOrder("1.5.8") and VersionOrder(version) <= VersionOrder("1.5.11"):
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
     if name == "tesseract" and version == "5.2.0":
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")

--- a/main.py
+++ b/main.py
@@ -1469,6 +1469,12 @@ def patch_record_in_place(fn, record, subdir):
             (version == "3.4.0" and build_number < 1)):
         replace_dep(depends, "poppler", "poppler <=22.12.0")
 
+    # libarchive 3.7.5 abi breaking change - https://github.com/libarchive/libarchive/pull/1976
+    if name == "libmamba" and VersionOrder(version) >= VersionOrder("1.5.8") and VersionOrder(version) >= VersionOrder("1.5.11"):
+        replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
+    if name == "tesseract" and version == "5.2.0":
+        replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
+
     ###########################
     # compilers and run times #
     ###########################

--- a/r.py
+++ b/r.py
@@ -198,6 +198,13 @@ def _patch_repodata(repodata, subdir):
                     pass
                 record['depends'].append('r-base 3.1.2')
                 instructions["packages"][fn]["depends"] = record['depends']
+        elif record_name == "r-archive" and record['version'] == "1.1.9":
+            # libarchive 3.7.5 abi breaking change - https://github.com/libarchive/libarchive/pull/1976
+            try:
+                record['depends'].remove('libarchive >=3.7.4,<3.8.0a0')
+            except ValueError:
+                pass
+            record['depends'].append('libarchive >=3.7.4,<3.7.5.0a0')
 
         # Every artifact's metadata requires 'subdir'.
         if "subdir" not in record:


### PR DESCRIPTION
libarchive introduced an abi breaking change (for us) in 3.7.5: https://github.com/libarchive/libarchive/pull/1976

This change protects existing affected packages.