### PR TITLE
add constrains to libarchive

### DIFF
--- a/main.py
+++ b/main.py
@@ -1479,7 +1479,6 @@ def patch_record_in_place(fn, record, subdir):
         # also from incoming "new libarchive" as incompatible with "installed libmamba"
         record["constrains"] = ["libmamba <0"]
 
-
     if name == "tesseract" and version == "5.2.0":
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
 

--- a/main.py
+++ b/main.py
@@ -1473,6 +1473,13 @@ def patch_record_in_place(fn, record, subdir):
     if (name == "libmamba" and VersionOrder(version) >= VersionOrder("1.5.8") and
             VersionOrder(version) <= VersionOrder("1.5.11")):
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
+        # incompatible with libmamba, breaking conda-libmamba-solver
+
+    if (name == "libarchive" and version == "3.7"):
+        # also from incoming "new libarchive" as incompatible with "installed libmamba"
+        record["constrains"] = ["libmamba < 0"]
+
+
     if name == "tesseract" and version == "5.2.0":
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
 

--- a/main.py
+++ b/main.py
@@ -1475,9 +1475,9 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
         # incompatible with libmamba, breaking conda-libmamba-solver
 
-    if (name == "libarchive" and version == "3.7"):
+    if (name == "libarchive" and version == "3.7.7" and build_number == "0"):
         # also from incoming "new libarchive" as incompatible with "installed libmamba"
-        record["constrains"] = ["libmamba < 0"]
+        record["constrains"] = ["libmamba <0"]
 
 
     if name == "tesseract" and version == "5.2.0":


### PR DESCRIPTION
{package} {version} {:snowflake:}

**Destination channel:** {Snowflake | defaults}

### Links

- [{ticket_number}]() 
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- libarchive 3.7 (build 0 only?) is very incompatible with libmamba
- What prevents us from removing the package entirely?