### PR TITLE
Apply hotfixes for cudnn compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -627,6 +627,25 @@ def patch_record_in_place(fn, record, subdir):
     if fn == "cupti-9.0.176-0.tar.bz2":
         replace_dep(depends, "cudatoolkit 9.*", "cudatoolkit 9.0.*")
 
+    # documentation on cudnn versions before 8.5.0 is now unavailable.
+    # cudnn 8.9.2 is max compatible with cudatoolkit 12.1; glibc 2.19 on x86_64; glibc 2.28 on aarch64
+    # https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-892/support-matrix/index.html
+    # cudnn 9.1.1 is max compatible with cudatoolkit 12.4; glibc 2.28 on x86_64; glibc 2.28 on aarch64
+    # https://docs.nvidia.com/deeplearning/cudnn/backend/v9.1.1/reference/support-matrix.html#linux
+    if name == "cudnn" and version == "8.9.2.26":
+        if build.startswith("cuda12"):
+            replace_dep(depends, "cuda-version 12.*", "cuda-version <=12.1")
+        if subdir == "linux-64":
+            depends.append("__glibc >=2.19")
+        if subdir == "linux-aarch64":
+            depends.append("__glibc >=2.28")
+    if name == "cudnn" and version == "9.1.1.17":
+        if build.startswith("cuda12"):
+            replace_dep(depends, "cuda-version 12.*", "cuda-version <=12.4")
+        if subdir == "linux-64" or subdir == "linux-aarch64":
+            depends.append("__glibc >=2.28")
+
+
     #######
     # MKL #
     #######

--- a/main.py
+++ b/main.py
@@ -634,15 +634,14 @@ def patch_record_in_place(fn, record, subdir):
     # https://docs.nvidia.com/deeplearning/cudnn/backend/v9.1.1/reference/support-matrix.html#linux
     if name == "cudnn" and version == "8.9.2.26":
         if build.startswith("cuda12"):
-            replace_dep(depends, "cuda-version 12.*", "cuda-version <=12.1")
+            replace_dep(depends, "cuda-version 12.*", "cuda-version >=12,<=12.1")
         if subdir == "linux-aarch64":
             depends.append("__glibc >=2.28")
     if name == "cudnn" and version == "9.1.1.17":
         if build.startswith("cuda12"):
-            replace_dep(depends, "cuda-version 12.*", "cuda-version <=12.4")
+            replace_dep(depends, "cuda-version 12.*", "cuda-version >=12,<=12.4")
         if subdir == "linux-64" or subdir == "linux-aarch64":
             depends.append("__glibc >=2.28")
-
 
     #######
     # MKL #

--- a/main.py
+++ b/main.py
@@ -628,15 +628,13 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "cudatoolkit 9.*", "cudatoolkit 9.0.*")
 
     # documentation on cudnn versions before 8.5.0 is now unavailable.
-    # cudnn 8.9.2 is max compatible with cudatoolkit 12.1; glibc 2.19 on x86_64; glibc 2.28 on aarch64
+    # cudnn 8.9.2 is max compatible with cudatoolkit 12.1; glibc 2.17 on x86_64; glibc 2.28 on aarch64
     # https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-892/support-matrix/index.html
     # cudnn 9.1.1 is max compatible with cudatoolkit 12.4; glibc 2.28 on x86_64; glibc 2.28 on aarch64
     # https://docs.nvidia.com/deeplearning/cudnn/backend/v9.1.1/reference/support-matrix.html#linux
     if name == "cudnn" and version == "8.9.2.26":
         if build.startswith("cuda12"):
             replace_dep(depends, "cuda-version 12.*", "cuda-version <=12.1")
-        if subdir == "linux-64":
-            depends.append("__glibc >=2.19")
         if subdir == "linux-aarch64":
             depends.append("__glibc >=2.28")
     if name == "cudnn" and version == "9.1.1.17":


### PR DESCRIPTION
cudnn has dependencies on cuda and glibc which are currently undeclared:
- cudnn 8.9.2 is max compatible with cudatoolkit 12.1; glibc 2.19 on x86_64; glibc 2.28 on aarch64: https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-892/support-matrix/index.html
- cudnn 9.1.1 is max compatible with cudatoolkit 12.4; glibc 2.28 on x86_64; glibc 2.28 on aarch64: https://docs.nvidia.com/deeplearning/cudnn/backend/v9.1.1/reference/support-matrix.html#linux

Below is the output from `test-hotfix.py`
    
```
(bld) dpetry@Daniels-MacBook-Pro ~/Sandbox/distro-tools/repodata-hotfixes (dpetry/cudnn-glibc-compat) $ python test-hotfix.py main --subdirs linux-64 linux-aarch64
Creating channel directory structure for channel 'main' and platforms ['linux-64', 'linux-aarch64']
Applying url to alias main. channel_base_url='https://repo.anaconda.com/pkgs/main'
Cloning subdirs linux-64 linux-aarch64...
downloading repodata from https://repo.anaconda.com/pkgs/main/linux-64/repodata.json
downloading repodata from https://repo.anaconda.com/pkgs/main/linux-64/repodata_from_packages.json
downloading repodata from https://repo.anaconda.com/pkgs/main/linux-aarch64/repodata.json
downloading repodata from https://repo.anaconda.com/pkgs/main/linux-aarch64/repodata_from_packages.json
Executing hotfix for channel 'main'.
Completed hotfix for channel 'main'.
Analyzing results...
Writing out new repodata as main/linux-64/repodata-patched.json for 'linux-64' platform.
*** main/linux-64/repodata-reference.json	Mon Mar  3 17:11:46 2025
--- main/linux-64/repodata-patched.json	Mon Mar  3 17:11:57 2025
***************
*** 284005,284015 ****
      },
      "cudnn-8.9.2.26-cuda11_0.tar.bz2": {
        "build": "cuda11_0",
        "build_number": 0,
        "depends": [
!         "cudatoolkit 11.*"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "f14a9062c89e9ec355a0a3dbcfa6aa99",
        "name": "cudnn",
--- 284005,284016 ----
      },
      "cudnn-8.9.2.26-cuda11_0.tar.bz2": {
        "build": "cuda11_0",
        "build_number": 0,
        "depends": [
!         "cudatoolkit 11.*",
!         "__glibc >=2.19"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "f14a9062c89e9ec355a0a3dbcfa6aa99",
        "name": "cudnn",
***************
*** 284022,284033 ****
      "cudnn-8.9.2.26-cuda12_0.tar.bz2": {
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "9fa61e20f59190eee832c178032c6a5e",
        "name": "cudnn",
--- 284023,284035 ----
      "cudnn-8.9.2.26-cuda12_0.tar.bz2": {
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version <=12.1",
!         "libcublas",
!         "__glibc >=2.19"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "9fa61e20f59190eee832c178032c6a5e",
        "name": "cudnn",
***************
*** 284040,284051 ****
      "cudnn-9.1.1.17-cuda12_0.tar.bz2": {
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "5d6516b9ddddbe7aa74d7805ae548920",
        "name": "cudnn",
--- 284042,284054 ----
      "cudnn-9.1.1.17-cuda12_0.tar.bz2": {
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version <=12.4",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "5d6516b9ddddbe7aa74d7805ae548920",
        "name": "cudnn",
***************
*** 284058,284069 ****
      "cudnn-9.1.1.17-cuda12_1.tar.bz2": {
        "build": "cuda12_1",
        "build_number": 1,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "9f88366a673c9347298a27ae10731c49",
        "name": "cudnn",
--- 284061,284073 ----
      "cudnn-9.1.1.17-cuda12_1.tar.bz2": {
        "build": "cuda12_1",
        "build_number": 1,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version <=12.4",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "9f88366a673c9347298a27ae10731c49",
        "name": "cudnn",
***************
*** 1319011,1319021 ****
      },
      "cudnn-8.9.2.26-cuda11_0.conda": {
        "build": "cuda11_0",
        "build_number": 0,
        "depends": [
!         "cudatoolkit 11.*"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "e589bfd90e598c42a088794e61ad6be2",
        "name": "cudnn",
--- 1319015,1319026 ----
      },
      "cudnn-8.9.2.26-cuda11_0.conda": {
        "build": "cuda11_0",
        "build_number": 0,
        "depends": [
!         "cudatoolkit 11.*",
!         "__glibc >=2.19"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "e589bfd90e598c42a088794e61ad6be2",
        "name": "cudnn",
***************
*** 1319028,1319039 ****
      "cudnn-8.9.2.26-cuda12_0.conda": {
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "511a70e95dfc98f6c6ab1a7b453a09da",
        "name": "cudnn",
--- 1319033,1319045 ----
      "cudnn-8.9.2.26-cuda12_0.conda": {
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version <=12.1",
!         "libcublas",
!         "__glibc >=2.19"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "511a70e95dfc98f6c6ab1a7b453a09da",
        "name": "cudnn",
***************
*** 1319046,1319057 ****
      "cudnn-9.1.1.17-cuda12_0.conda": {
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "a64c4e255e55eab4d50720fe93d18979",
        "name": "cudnn",
--- 1319052,1319064 ----
      "cudnn-9.1.1.17-cuda12_0.conda": {
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version <=12.4",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "a64c4e255e55eab4d50720fe93d18979",
        "name": "cudnn",
***************
*** 1319064,1319075 ****
      "cudnn-9.1.1.17-cuda12_1.conda": {
        "build": "cuda12_1",
        "build_number": 1,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "a0b03d2faafd80742a7fcce40fcc028e",
        "name": "cudnn",
--- 1319071,1319083 ----
      "cudnn-9.1.1.17-cuda12_1.conda": {
        "build": "cuda12_1",
        "build_number": 1,
        "depends": [
          "cuda-nvrtc",
!         "cuda-version <=12.4",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "a0b03d2faafd80742a7fcce40fcc028e",
        "name": "cudnn",
Writing out new repodata as main/linux-aarch64/repodata-patched.json for 'linux-aarch64' platform.
*** main/linux-aarch64/repodata-reference.json	Mon Mar  3 17:11:47 2025
--- main/linux-aarch64/repodata-patched.json	Mon Mar  3 17:11:58 2025
***************
*** 149615,149626 ****
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "a62fb242ac534c11bb0f752e9fed4a52",
        "name": "cudnn",
--- 149615,149627 ----
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version <=12.1",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "a62fb242ac534c11bb0f752e9fed4a52",
        "name": "cudnn",
***************
*** 149634,149645 ****
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "883d0a13235d078940897340e44ae0a3",
        "name": "cudnn",
--- 149635,149647 ----
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version <=12.4",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "883d0a13235d078940897340e44ae0a3",
        "name": "cudnn",
***************
*** 149653,149664 ****
        "build": "cuda12_1",
        "build_number": 1,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "c47b7828d7f4061d1acdd8e57e6de451",
        "name": "cudnn",
--- 149655,149667 ----
        "build": "cuda12_1",
        "build_number": 1,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version <=12.4",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "c47b7828d7f4061d1acdd8e57e6de451",
        "name": "cudnn",
***************
*** 687950,687961 ****
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "2211c091ab38dd54e31be75d7a4257b0",
        "name": "cudnn",
--- 687953,687965 ----
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version <=12.1",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "2211c091ab38dd54e31be75d7a4257b0",
        "name": "cudnn",
***************
*** 687969,687980 ****
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "5465d7a8e0cef04e70078e0f54a281b7",
        "name": "cudnn",
--- 687973,687985 ----
        "build": "cuda12_0",
        "build_number": 0,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version <=12.4",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "5465d7a8e0cef04e70078e0f54a281b7",
        "name": "cudnn",
***************
*** 687988,687999 ****
        "build": "cuda12_1",
        "build_number": 1,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version 12.*",
!         "libcublas"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "bd1f591827f05530f5b601b304a2be3c",
        "name": "cudnn",
--- 687993,688005 ----
        "build": "cuda12_1",
        "build_number": 1,
        "depends": [
          "__glibc >=2.27",
          "cuda-nvrtc",
!         "cuda-version <=12.4",
!         "libcublas",
!         "__glibc >=2.28"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "PROPRIETARY",
        "md5": "bd1f591827f05530f5b601b304a2be3c",
        "name": "cudnn",
```
