### PR TITLE
Fix intel-openmp __glibc runtime constraint

### DIFF
--- a/main.py
+++ b/main.py
@@ -858,6 +858,10 @@ def patch_record_in_place(fn, record, subdir):
         # or pyopenssl should have a max cryptography version set
         record["constrains"] = ["pyopenssl >=23.0.0"]
 
+    # intel-openmp requires newer glibc.
+    if name == "intel-openmp" and version == "2025.0.0":
+        replace_dep(constrains, "__glibc >=2.17", "__glibc >=2.26")
+
     ############
     # features #
     ############


### PR DESCRIPTION
### Explanation of changes:

- Update `intel-openmp` v2025.0.0 to use proper runtime constraint on `__glibc >=2.26`
