### PR TITLE
py-lief<0.15 for conda-build <25.3.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -977,6 +977,11 @@ def patch_record_in_place(fn, record, subdir):
             if dep_name == "menuinst" and VersionOrder(version) <= VersionOrder("3.28.1"):
                 depends[i] = "menuinst >=2.0.1"
 
+            # API changes in py-lief 0.15 affect conda-build <25.3.0
+            # https://github.com/conda/conda-build/blob/main/CHANGELOG.md#2530-2025-03-17
+            if dep_name == "py-lief" and VersionOrder(version) > VersionOrder("25.3.0"):
+                depends[i] = "py-lief <0.15"
+
     if name == "constructor":
         if int(version[0]) < 3:
             replace_dep(depends, "conda", "conda <4.6.0a0")


### PR DESCRIPTION
### Explanation of changes:

    API changes in py-lief 0.15 affect conda-build <25.3.0
    https://github.com/conda/conda-build/blob/main/CHANGELOG.md#2530-2025-03-17