### PR TITLE
c-blosc2 2.14.4 abi change

### DIFF
--- a/main.py
+++ b/main.py
@@ -1541,6 +1541,12 @@ def patch_record_in_place(fn, record, subdir):
     if name == "tesseract" and version == "5.2.0":
         replace_dep(depends, "libarchive >=3.7.4,<3.8.0a0", "libarchive >=3.7.4,<3.7.5.0a0")
 
+    # c-blosc2 2.14.4 abi breaking change - https://github.com/Blosc/c-blosc2/issues/581
+    if name in ("pytables", "tables"):
+        replace_dep(depends, "c-blosc2 >=2.8.0,<3.0a0", "c-blosc2 >=2.8.0,<2.14.4.0a0")
+        replace_dep(depends, "c-blosc2 >=2.10.5,<3.0a0", "c-blosc2 >=2.10.5,<2.14.4.0a0")
+        replace_dep(depends, "c-blosc2 >=2.12.0,<3.0a0", "c-blosc2 >=2.12.0,<2.14.4.0a0")
+
     # https://github.com/conda-incubator/conda-project/issues/183
     if name == "conda-project" and VersionOrder(version) <= VersionOrder("0.4.2"):
         replace_dep(depends, "conda-lock >=2.5.6", "conda-lock >=2.5.6,<3.0.0.0a0")


### PR DESCRIPTION
c-blosc2 2.14.4 abi change

### Explanation of changes:
- https://github.com/AnacondaRecipes/c-blosc2-feedstock/pull/6
- https://github.com/Blosc/c-blosc2/issues/581
- The soname has changed in release 2.14.4.