### PR TITLE
URSA-155: Install conda-anaconda-tos>=0.2.0 for conda>=24.11.0.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1455,6 +1455,16 @@ def patch_record_in_place(fn, record, subdir):
             if not dep.startswith("conda-anaconda-telemetry ")
         ] + ["conda-anaconda-telemetry >=0.1.2"]
 
+    # Add run constraint for conda to require conda-anaconda-tos
+    # with the lowest possible version of conda that is compatible with the current version
+    # of conda-anaconda-tos
+    if name == "conda" and VersionOrder(version) >= VersionOrder("24.11.0"):
+        constrains[:] = [
+            dep
+            for dep in constrains
+            if not dep.startswith("conda-anaconda-tos ")
+        ] + ["conda-anaconda-tos >=0.2.0"]
+
     if name == "conda-libmamba-solver":
         # libmambapy 0.23 introduced breaking changes
         replace_dep(depends, "libmambapy >=0.22.1", "libmambapy 0.22.*")


### PR DESCRIPTION
## Add run constraint for `conda-anaconda-tos` to `conda>=24.11.0`

[URSA-155](https://anaconda.atlassian.net/issues/URSA-155)

### Summary
This PR adds a run constraint to ensure that conda packages version 24.11.0 and above require `conda-anaconda-tos>=0.2.0`.

### Changes
- Added a new hotfix section in `main.py` that patches repodata for conda>=24.11.0
- The constraint ensures compatibility with the lowest possible version of conda that works with the current version of `conda-anaconda-tos`
- Follows the same pattern as the existing `conda-anaconda-telemetry` constraint for consistency

### Technical Details
The hotfix:
1. Checks if the package name is "conda" and the version is `>= 24.11.0`
2. Filters out any existing `conda-anaconda-tos` constraints from the constraints list
3. Adds the new constraint `conda-anaconda-tos >=0.2.0`

### Why This Change is Needed
This ensures that users installing conda 24.11.0 or later will automatically get a compatible version of `conda-anaconda-tos`, preventing potential compatibility issues and ensuring proper functionality of the terms of service plugin.

### Testing
- [ ] Verify the hotfix applies correctly to conda>=24.11.0 packages
- [ ] Confirm existing conda versions (<24.11.0) are unaffected
- [ ] Test that the constraint properly resolves to `conda-anaconda-tos>=0.2.0`

### Related
This change complements the existing conda-anaconda-telemetry constraint added for conda>=24.11.0 and maintains consistency in how conda plugin dependencies are managed.

[URSA-155]: https://anaconda.atlassian.net/browse/URSA-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ