### PR TITLE
Remove broken libcxx.

### DIFF
--- a/main.py
+++ b/main.py
@@ -50,11 +50,11 @@ REMOVALS = {
         "cffi-1.14.6-py37h9ed2024_0.tar.bz2",
         "cffi-1.14.6-py38h9ed2024_0.tar.bz2",
         "cffi-1.14.6-py39h9ed2024_0.tar.bz2",
-        # libcxx-17.0.6*1 is missing run_constrained which breaks clang 14. 
+        # libcxx-17.0.6*1 is missing run_constrained which breaks clang 14.
         "libcxx-17.0.6-hf547dac_1.tar.bz2",
     ],
     "osx-arm64": [
-         # libcxx-17.0.6*1 is missing run_constrained which breaks clang 14. 
+        # libcxx-17.0.6*1 is missing run_constrained which breaks clang 14.
         "libcxx-17.0.6-he5c5206_1.tar.bz2",
     ],
     "win-32": [


### PR DESCRIPTION
```
Writing out new repodata as main/osx-64/repodata-patched.json for 'osx-64' platform.


*** main/osx-64/repodata-reference.json	Wed Jun 18 08:17:13 2025
--- main/osx-64/repodata-patched.json	Wed Jun 18 08:17:36 2025
***************
*** 472743,472766 ****
        "size": 1391293,
        "subdir": "osx-64",
        "timestamp": 1662620489455,
        "version": "14.0.6"
      },
-     "libcxx-17.0.6-hf547dac_1.tar.bz2": {
-       "build": "hf547dac_1",
-       "build_number": 1,
-       "depends": [],
-       "license": "Apache-2.0 WITH LLVM-exception",
-       "license_family": "Apache",
-       "md5": "e5c4f0f4fd8bdb9d6ed23c327d98339c",
-       "name": "libcxx",
-       "sha256": "158d7dc69f59c42dd09c12adf0f7d7d1bdee830d5a2f4f5854a8946a66447738",
-       "size": 391097,
-       "subdir": "osx-64",
-       "timestamp": 1750123932455,
-       "version": "17.0.6"
-     },
      "libcxx-17.0.6-hf547dac_2.tar.bz2": {
        "build": "hf547dac_2",
        "build_number": 2,
        "constrains": [
          "llvm 17.0.6",
--- 472743,472752 ----
***************
*** 1496678,1496701 ****
        "size": 990864,
        "subdir": "osx-64",
        "timestamp": 1662620489455,
        "version": "14.0.6"
      },
-     "libcxx-17.0.6-hf547dac_1.conda": {
-       "build": "hf547dac_1",
-       "build_number": 1,
-       "depends": [],
-       "license": "Apache-2.0 WITH LLVM-exception",
-       "license_family": "Apache",
-       "md5": "6450d3951d9b16037ada4d32acadd074",
-       "name": "libcxx",
-       "sha256": "2971fbcc1e6b10898ecb22b87491ffc127f1e4a9ab1b6feaabc4b17be2bfc464",
-       "size": 333984,
-       "subdir": "osx-64",
-       "timestamp": 1750123932455,
-       "version": "17.0.6"
-     },
      "libcxx-17.0.6-hf547dac_2.conda": {
        "build": "hf547dac_2",
        "build_number": 2,
        "constrains": [
          "llvm 17.0.6",
--- 1496664,1496673 ----
***************
*** 2048119,2048126 ****
        "subdir": "osx-64",
        "timestamp": 1595965109852,
        "version": "1.4.5"
      }
    },
!   "removed": [],
    "repodata_version": 1
  }
--- 2048091,2048101 ----
        "subdir": "osx-64",
        "timestamp": 1595965109852,
        "version": "1.4.5"
      }
    },
!   "removed": [
!     "libcxx-17.0.6-hf547dac_1.conda",
!     "libcxx-17.0.6-hf547dac_1.tar.bz2"
!   ],
    "repodata_version": 1
  }
Writing out new repodata as main/osx-arm64/repodata-patched.json for 'osx-arm64' platform.
*** main/osx-arm64/repodata-reference.json	Wed Jun 18 08:17:15 2025
--- main/osx-arm64/repodata-patched.json	Wed Jun 18 08:31:29 2025
***************
*** 271454,271477 ****
        "size": 1387034,
        "subdir": "osx-arm64",
        "timestamp": 1662620483620,
        "version": "14.0.6"
      },
-     "libcxx-17.0.6-he5c5206_1.tar.bz2": {
-       "build": "he5c5206_1",
-       "build_number": 1,
-       "depends": [],
-       "license": "Apache-2.0 WITH LLVM-exception",
-       "license_family": "Apache",
-       "md5": "7d1d157b7ba48748f87f22e00dd0f4ce",
-       "name": "libcxx",
-       "sha256": "276814738b2528233a149ff6b647858ddb0814709d0cfc34c08cf7e83295dbd3",
-       "size": 376215,
-       "subdir": "osx-arm64",
-       "timestamp": 1750123888179,
-       "version": "17.0.6"
-     },
      "libcxx-17.0.6-he5c5206_2.tar.bz2": {
        "build": "he5c5206_2",
        "build_number": 2,
        "constrains": [
          "clang 17.0.6",
--- 271454,271463 ----
***************
*** 840879,840902 ****
        "size": 987661,
        "subdir": "osx-arm64",
        "timestamp": 1662620483620,
        "version": "14.0.6"
      },
-     "libcxx-17.0.6-he5c5206_1.conda": {
-       "build": "he5c5206_1",
-       "build_number": 1,
-       "depends": [],
-       "license": "Apache-2.0 WITH LLVM-exception",
-       "license_family": "Apache",
-       "md5": "56e89f264e72cd831b43cea40a23395e",
-       "name": "libcxx",
-       "sha256": "0a263cce3407974dad330f20a8d1faf7a72ebf158f134c00dd2b3983a09e82a3",
-       "size": 315962,
-       "subdir": "osx-arm64",
-       "timestamp": 1750123888179,
-       "version": "17.0.6"
-     },
      "libcxx-17.0.6-he5c5206_2.conda": {
        "build": "he5c5206_2",
        "build_number": 2,
        "constrains": [
          "clang 17.0.6",
--- 840865,840874 ----
***************
*** 1138695,1138702 ****
        "subdir": "osx-arm64",
        "timestamp": 1728486986031,
        "version": "1.5.6"
      }
    },
!   "removed": [],
    "repodata_version": 1
  }
--- 1138667,1138677 ----
        "subdir": "osx-arm64",
        "timestamp": 1728486986031,
        "version": "1.5.6"
      }
    },
!   "removed": [
!     "libcxx-17.0.6-he5c5206_1.conda",
!     "libcxx-17.0.6-he5c5206_1.tar.bz2"
!   ],
    "repodata_version": 1
  }
```