### PR TITLE
Fix OSX compilers to require a sysroot

### DIFF
--- a/main.py
+++ b/main.py
@@ -1600,6 +1600,11 @@ def patch_record_in_place(fn, record, subdir):
         if name == "clangxx_osx-64" and version == "4.0.1" and int(build_number) < 17:
             depends[:] = ["clang_osx-64 >=4.0.1,<4.0.2.0a0", "clangxx", "libcxx"]
 
+    # Update older compiler packages to require an OSX sysroot that matches their platform.
+    if (subdir.startswith("osx") and name == "clang" and VersionOrder(version) <= VersionOrder("17.0.6")
+            and int(build_number) < 5):
+        depends.append("macosx_deployment_target_" + subdir)
+
     ###########
     # numpy 2 #
     ###########


### PR DESCRIPTION
clang

**Destination channel:** defaults

### Links

- [PKG-8364](https://anaconda.atlassian.net/browse/PKG-8364)
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- Add the new OSX sysroot package to older compiler metapackages so that omitting `{{ stdlib('c') }}` in a recipe will still fallback on using the default sysroot version for each platform.
