### PR TITLE
Update conda-anaconda-telemetry version constraint to >=0.2.0 

### DIFF
--- a/main.py
+++ b/main.py
@@ -1454,12 +1454,13 @@ def patch_record_in_place(fn, record, subdir):
     # Add run constraint for conda to fix plugin here:
     # https://github.com/anaconda/conda-anaconda-telemetry/issues/87
     # https://github.com/anaconda/conda-anaconda-telemetry/pull/96
+    # https://github.com/anaconda/conda-anaconda-telemetry/issues/127
     if name in ("conda", "conda-build") and VersionOrder(version) >= VersionOrder("24.11.0"):
         constrains[:] = [
             dep
             for dep in constrains
             if not dep.startswith("conda-anaconda-telemetry ")
-        ] + ["conda-anaconda-telemetry >=0.1.2"]
+        ] + ["conda-anaconda-telemetry >=0.2.0"]
 
     if name == "conda-libmamba-solver":
         # libmambapy 0.23 introduced breaking changes


### PR DESCRIPTION
Also add reference to issue https://github.com/anaconda/conda-anaconda-telemetry/issues/127

conda-anaconda-telemetry 0.2.0

Refs https://github.com/AnacondaRecipes/private_conda_recipes/pull/291 and [PKG-8620](https://anaconda.atlassian.net/browse/PKG-8620)

### Explanation of changes:

- We need to prevent older versions of conda-anaconda-telemetry from being installed with conda to fix an issue with the plugin and non-cloned channels on anaconda.org.

[PKG-8620]: https://anaconda.atlassian.net/browse/PKG-8620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ