### PR TITLE
anaconda-toolbox 4.20.0 is not stable for Python 3.13

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,6 +155,8 @@ REVOKED = {
         "spyder-5.5.1-*_2.*",
         # anaconda-cli-base-0.4.1 build number 0 has missing run_constrained requirements
         "anaconda-cli-base-0.4.1-*_0.*",
+        # anaconda-toolbox 4.20.0 is not stable for Python 3.13
+        "anaconda-toolbox-4.20.0-py313*",
     ],
 }
 


### PR DESCRIPTION
It was found that the `anaconda-toolbox` extension is not very stable with Python 3.13 up to **<=4.26.1**, and it requires fixing the small issues (See a [comment in JIRA](https://anaconda.atlassian.net/browse/PKG-8548?focusedCommentId=310387&atlOrigin=eyJpIjoiZDgzZjk1OGIxOTc0NDI2ZmE0NGRiZTg2YTI3MTUyNDQiLCJwIjoiaiJ9)) that are planned in the next release, but not in the current version `4.26.1`.

I skipped building `v4.26.1` for `py313`, see https://github.com/AnacondaRecipes/anaconda-toolbox-feedstock/pull/7/files#diff-f3725a55bf339595bf865fec73bda8ac99f283b0810c205442021f29c06eea9aR15.

The only version we should revoke for `Python 3.13` is `4.20.0`.
All anaconda-toolbox dependencies like `aext-*` have exact pinning every release, so we do not need to hotfix them.

Testing the result of the hotfix by running:
`python test-hotfix.py main --subdir linux-64 osx-64 win-64 osx-arm64 linux-aarch64 noarch`

for example:
```
Writing out new repodata as main/linux-64/repodata-patched.json for 'linux-64' platform.
*** main/linux-64/repodata-reference.json	Tue Jul  8 13:32:51 2025
--- main/linux-64/repodata-patched.json	Tue Jul  8 13:34:48 2025
***************
*** 188335,188350 ****
          "anaconda-auth >=0.7.1",
          "jupyter_server >=2.10.0,<3",
          "jupyterlab >=4.0.9,<5",
          "nbconvert",
          "python >=3.13,<3.14.0a0",
!         "python_abi 3.13.* *_cp313"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "Other",
        "md5": "f7ebe78c94a4f64a8fd578d52bd7c9b8",
        "name": "anaconda-toolbox",
        "sha256": "a67619974ea99436dd87180438ca0a1cf2d7955fda60f2b95ea4aadd7934f1fd",
        "size": 47502829,
        "subdir": "linux-64",
        "summary": "Anaconda Assistant\n\nJupyterLab supercharged with a suite of Anaconda extensions, starting with the Anaconda Assistant AI chatbot.",
        "timestamp": 1746568386984,
--- 188335,188352 ----
          "anaconda-auth >=0.7.1",
          "jupyter_server >=2.10.0,<3",
          "jupyterlab >=4.0.9,<5",
          "nbconvert",
          "python >=3.13,<3.14.0a0",
!         "python_abi 3.13.* *_cp313",
!         "package_has_been_revoked"
        ],
        "license": "LicenseRef-Proprietary",
        "license_family": "Other",
        "md5": "f7ebe78c94a4f64a8fd578d52bd7c9b8",
        "name": "anaconda-toolbox",
+       "revoked": true,
        "sha256": "a67619974ea99436dd87180438ca0a1cf2d7955fda60f2b95ea4aadd7934f1fd",
        "size": 47502829,
        "subdir": "linux-64",
        "summary": "Anaconda Assistant\n\nJupyterLab supercharged with a suite of Anaconda extensions, starting with the Anaconda Assistant AI chatbot.",
        "timestamp": 1746568386984,
```


