### PR TITLE
Require conda-anaconda-tos 0.2.1.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1470,7 +1470,7 @@ def patch_record_in_place(fn, record, subdir):
             dep
             for dep in constrains
             if not dep.startswith("conda-anaconda-tos ")
-        ] + ["conda-anaconda-tos >=0.2.0"]
+        ] + ["conda-anaconda-tos >=0.2.1"]
 
     if name == "conda-libmamba-solver":
         # libmambapy 0.23 introduced breaking changes


### PR DESCRIPTION
conda-anaconda-tos 0.2.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/anaconda/conda-anaconda-tos)
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - https://github.com/anaconda/conda-anaconda-tos/issues/231

### Explanation of changes:

- This is an urgent change to require the just released conda-anaconda-tos 0.2.1
