### PR TITLE
constrain pytorch to corresponding libtorch variant

### DIFF
--- a/main.py
+++ b/main.py
@@ -778,6 +778,11 @@ def patch_record_in_place(fn, record, subdir):
         else:
             depends.append("_pytorch_select 0.1")
 
+    if name == "pytorch" and version in ["2.5.1", "2.6.0"] and subdir in ["linux-64", "osx-arm64"]:
+        # pytorch 2.5.1 and 2.6.0 are missing a constraint to match libtorch dependency to the same
+        # type of build (cpu vs gpu)
+        replace_dep(depends, f"libtorch {version}.*", f"libtorch {version}.* *_{build_number}")
+
     #########
     # scipy #
     #########


### PR DESCRIPTION
constrain pytorch to corresponding libtorch variant.

At the moment, it is possible to install pytorch gpu with the cpu variant of libtorch. This can lead to crashes.

Discovered while working on https://github.com/AnacondaRecipes/llama.cpp-feedstock/pull/16