### PR TITLE
Bump up constraint for conda-anaconda-telemetry to 0.3.0.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1478,12 +1478,13 @@ def patch_record_in_place(fn, record, subdir):
     # https://github.com/anaconda/conda-anaconda-telemetry/issues/87
     # https://github.com/anaconda/conda-anaconda-telemetry/pull/96
     # https://github.com/anaconda/conda-anaconda-telemetry/issues/127
+    # https://github.com/anaconda/conda-anaconda-telemetry/issues/130
     if name in ("conda", "conda-build") and VersionOrder(version) >= VersionOrder("24.11.0"):
         constrains[:] = [
             dep
             for dep in constrains
             if not dep.startswith("conda-anaconda-telemetry ")
-        ] + ["conda-anaconda-telemetry >=0.2.0"]
+        ] + ["conda-anaconda-telemetry >=0.3.0"]
 
     # Add run constraint for conda to require conda-anaconda-tos
     # with the lowest possible version of conda that is compatible with the current version


### PR DESCRIPTION
conda-anaconda-telemetry 0.3.0

**Destination channel:** defaults

### Links

- [PKG-9286](https://anaconda.atlassian.net/browse/PKG-9286)
- [Upstream repository](https://github.com/anaconda/conda-anaconda-telemetry/)
- [Upstream changelog/diff](https://github.com/anaconda/conda-anaconda-telemetry/releases/tag/0.3.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/private_conda_recipes/pull/295

### Explanation of changes:

- Follow-up to https://github.com/AnacondaRecipes/private_conda_recipes/pull/295


[PKG-9286]: https://anaconda.atlassian.net/browse/PKG-9286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ