### PR TITLE
Adjust conda-anaconda-telemetry constraints for osx-64.

### DIFF
--- a/main.py
+++ b/main.py
@@ -1484,7 +1484,11 @@ def patch_record_in_place(fn, record, subdir):
             dep
             for dep in constrains
             if not dep.startswith("conda-anaconda-telemetry ")
-        ] + ["conda-anaconda-telemetry >=0.3.0"]
+        ]
+        if subdir == "osx-64":
+            constrains.append("conda-anaconda-telemetry >=0.2.0,<0.3.0")
+        else:
+            constrains.append("conda-anaconda-telemetry >=0.3.0")
 
     # Add run constraint for conda to require conda-anaconda-tos
     # with the lowest possible version of conda that is compatible with the current version


### PR DESCRIPTION
conda-anaconda-telemetry 0.3.0

**Destination channel:** defaults

- [PKG-9286](https://anaconda.atlassian.net/browse/PKG-9286)
- [Upstream repository](https://github.com/anaconda/conda-anaconda-telemetry/)
- [Upstream changelog/diff](https://github.com/anaconda/conda-anaconda-telemetry/releases/tag/0.3.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/private_conda_recipes/pull/295
  - https://github.com/AnacondaRecipes/repodata-hotfixes/pull/277

### Explanation of changes:

- Adjust conda-anaconda-telemetry constraints based on subdirectory: use version >=0.2.0,<0.3.0 for osx-64 and >=0.3.0 for others.

- Follow-up to https://github.com/AnacondaRecipes/private_conda_recipes/pull/295 and https://github.com/AnacondaRecipes/repodata-hotfixes/pull/277


[PKG-9286]: https://anaconda.atlassian.net/browse/PKG-9286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ