### PR TITLE
Use the new noarch release of conda-anaconda-telemetry (0.3.0-1).

### DIFF
--- a/main.py
+++ b/main.py
@@ -1484,7 +1484,7 @@ def patch_record_in_place(fn, record, subdir):
             dep
             for dep in constrains
             if not dep.startswith("conda-anaconda-telemetry ")
-        ] + ["conda-anaconda-telemetry >=0.3.0-1"]
+        ] + ["conda-anaconda-telemetry >=0.3.0"]
 
     # Add run constraint for conda to require conda-anaconda-tos
     # with the lowest possible version of conda that is compatible with the current version

--- a/main.py
+++ b/main.py
@@ -1484,11 +1484,7 @@ def patch_record_in_place(fn, record, subdir):
             dep
             for dep in constrains
             if not dep.startswith("conda-anaconda-telemetry ")
-        ]
-        if subdir == "osx-64":
-            constrains.append("conda-anaconda-telemetry >=0.2.0,<0.3.0")
-        else:
-            constrains.append("conda-anaconda-telemetry >=0.3.0")
+        ] + ["conda-anaconda-telemetry >=0.3.0-1"]
 
     # Add run constraint for conda to require conda-anaconda-tos
     # with the lowest possible version of conda that is compatible with the current version


### PR DESCRIPTION
conda-anaconda-telemetry 0.3.0-1

**Destination channel:** defaults

### Links

- [PKG-9286](https://anaconda.atlassian.net/browse/PKG-9286)
- [Upstream repository](https://github.com/anaconda/conda-anaconda-telemetry/)
- [Upstream changelog/diff](https://github.com/anaconda/conda-anaconda-telemetry/releases/tag/0.3.0)

### Explanation of changes:

Now that conda-anaconda-telemetry 0.3.0 is released as a noarch package via https://github.com/AnacondaRecipes/conda-anaconda-telemetry-feedstock/pull/1, we can also have osx-64 use that.

- Follow-up to:
  - https://github.com/AnacondaRecipes/private_conda_recipes/pull/295
  - https://github.com/AnacondaRecipes/repodata-hotfixes/pull/277
  - https://github.com/AnacondaRecipes/repodata-hotfixes/pull/278
  - https://github.com/AnacondaRecipes/conda-anaconda-telemetry-feedstock/pull/1
  - https://github.com/AnacondaRecipes/private_conda_recipes/pull/296


[PKG-9286]: https://anaconda.atlassian.net/browse/PKG-9286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ