### PR TITLE
Loosen existing zlib pins

### DIFF
--- a/main.py
+++ b/main.py
@@ -1665,6 +1665,17 @@ def patch_record_in_place(fn, record, subdir):
     if NUMPY_2_CHANGES:
         apply_numpy2_changes(record, subdir, fn)
 
+    ###########
+    # zlib 1.3 compatibility #
+    ###########
+
+    # Make existing packages built against zlib 1.2 compatible with zlib 1.3
+    # by changing the upper bound from <1.3.0a0 to <2.0.0a0
+    if subdir in ["win-64", "linux-64", "linux-aarch64", "osx-arm64"]:
+        replace_dep(depends, "zlib >=1.2.11,<1.3.0a0", "zlib >=1.2.11,<2.0.0a0")
+        replace_dep(depends, "zlib >=1.2.12,<1.3.0a0", "zlib >=1.2.12,<2.0.0a0")
+        replace_dep(depends, "zlib >=1.2.13,<1.3.0a0", "zlib >=1.2.13,<2.0.0a0")
+
 
 def replace_dep(depends, old, new, *, append=False):
     """


### PR DESCRIPTION
zlib 1.2.13-1.3.1

**Destination channel:** defaults

### Links

- [PKG-9454](https://anaconda.atlassian.net/browse/PKG-9454)
- Recipe: https://github.com/AnacondaRecipes/zlib-feedstock
- ABI report: https://github.com/AnacondaRecipes/zlib-feedstock/pull/22#issuecomment-3225826230


### Explanation of changes:

- zlib 1.3 was found to be ABI compatible with 1.2 while working on PR https://github.com/AnacondaRecipes/zlib-feedstock/pull/22 .

The goal is to make existing packages built against zlib 1.2 compatible with zlib 1.3 by changing the depends part.
zlib >=1.2.11,<1.3.0a0 to zlib >=1.2.11,<2.0.0a0
zlib >=1.2.12,<1.3.0a0 to zlib >=1.2.12,<2.0.0a0
zlib >=1.2.13,<1.3.0a0 to zlib >=1.2.13,<2.0.0a0
The patch will be restricted to packages on the main channel built for win-64, linux-64, linux-aarch64 and osx-arm-64.


[PKG-9454]: https://anaconda.atlassian.net/browse/PKG-9454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ