### PR TITLE
PKG-9733: anaconda-client 1.13.0 has issues with anaconda-auth

### DIFF
--- a/main.py
+++ b/main.py
@@ -1053,6 +1053,9 @@ def patch_record_in_place(fn, record, subdir):
         if re.match(r'1\.(?:\d|1[01])\.', version):  # < 1.12.0
             if replace_dep(depends, 'urllib3 >=1.26.4', 'urllib3 >=1.26.4,<2.0.0a') == '=':  # if no changes
                 depends.append('urllib3 <2.0.0a')
+        if version == "1.13.0":
+            # anaconda-client 1.13.0 is not fully compatible with anaconda-auth. Fixed in 1.13.1
+            record["constrains"] = ["anaconda-auth <0"]
 
     if name == 'anaconda-navigator':
         version_order = VersionOrder(version)


### PR DESCRIPTION
anaconda-client 1.13.0

**Destination channel:** defaults

### Links

- [PKG-9733](https://anaconda.atlassian.net/browse/PKG-9733) 
- [Upstream repository](https://github.com/anaconda/anaconda-client)
- [Upstream changelog/diff](https://github.com/anaconda/anaconda-client/compare/1.13.0...1.13.1)

### Explanation of changes:

`anaconda-client 1.13.0` has a bug that prevents `anaconda upload` from working properly in CI processes. We have released `anaconda-client 1.13.1`, but it turns out that `conda install anaconda-client` is preferring to leave `1.13.0` in place due to subtle solver behavior. See [this `conda-libmamba-solver` issue](https://github.com/conda/conda-libmamba-solver/issues/702) for details.

That said, `anaconda-client 1.13.0` works just fine with `anaconda-auth` is not present. So this hotfix simply adds `anaconda-auth <0` to its `constrains` list.

NOTE: This does mean that the current Anaconda distribution installers become inconsistent but this will be readily corrected the next time the user does any sort of package install or update.

[PKG-9733]: https://anaconda.atlassian.net/browse/PKG-9733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ