### PR TITLE
Bump `conda 25.9.0`'s `conda-libmamba-solver` version

### DIFF
--- a/main.py
+++ b/main.py
@@ -1480,6 +1480,9 @@ def patch_record_in_place(fn, record, subdir):
             if not dep.startswith("conda-build ")
         ] + ["conda-build >=3.27"]
 
+    if name == "conda" and version == "25.9.0":
+        replace_dep(depends, "conda-libmamba-solver >=24.11.0", "conda-libmamba-solver >=25.4.0")
+
     # Add run constraint for conda to fix plugin here:
     # https://github.com/anaconda/conda-anaconda-telemetry/issues/87
     # https://github.com/anaconda/conda-anaconda-telemetry/pull/96


### PR DESCRIPTION
conda 25.9.0

**Destination channel:** defaults

### Links

- [{ticket_number}]() 
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
  - ...

### Explanation of changes:

- https://github.com/conda/conda/pull/15285
