### PR TITLE
CLI-3: Add conda<25.9 bound for existing versions of conda-token

### DIFF
--- a/main.py
+++ b/main.py
@@ -1533,8 +1533,13 @@ def patch_record_in_place(fn, record, subdir):
             replace_dep(depends, "libmambapy >=0.23", "libmambapy >=0.23,<2.0.0a0")
             replace_dep(depends, "libmambapy >=0.22.1", "libmambapy >=0.22.1,<2.0.0a0")
 
-    if name == "conda-token" and VersionOrder(version) < VersionOrder("0.5.0"):
-        replace_dep(depends, "conda >=4.3", "conda >=4.3,<23.9")
+    if name == "conda-token" and VersionOrder(version) < VersionOrder("0.6.1"):
+        # conda-token <0.5.0 not compatible with conda >=23.9
+        # conda-token <0.6.1 not compatible with conda >=25.9
+        bound = ",<23.9" if VersionOrder(version) < VersionOrder("0.5.0") else ",<25.9"
+        for i, d in enumerate(depends):
+            if d.startswith("conda "):
+                depends[i] += bound
 
     # snowflake-snowpark-python cloudpickle pins
     if name == "snowflake-snowpark-python" and version == '0.6.0':


### PR DESCRIPTION
conda-token <0.6.1

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/anaconda/conda-token)
- [CLI-3](https://anaconda.atlassian.net/browse/CLI-3)

### Explanation of changes:

- conda-token 0.6.0 and older are not compatible with conda 25.9 and later due to the removal of a deprecated `conda.cli.python_api` module.


[CLI-3]: https://anaconda.atlassian.net/browse/CLI-3?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ