### PR TITLE
Pytorch 2.7/2.8 hotfix for libtorch dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -804,6 +804,16 @@ def patch_record_in_place(fn, record, subdir):
         # type of build (cpu vs gpu)
         replace_dep(depends, f"libtorch {version}.*", f"libtorch {version}.* *_{build_number}")
 
+    if name == "pytorch" and version in ["2.7.1", "2.8.0"]:
+        # pytorch 2.7.1 and 2.8.0 used libtorch {{ version }} instead of
+        # {{ pin_subpackage('libtorch', exact=True) }}, allowing the solver
+        # to mix CPU/GPU or MKL/OpenBLAS variants of libtorch and pytorch
+        replace_dep(
+            depends,
+            [f"libtorch {version}", f"libtorch {version}.*"],
+            f"libtorch {version}.* *_{build_number}",
+        )
+
     #########
     # scipy #
     #########


### PR DESCRIPTION
Get the right CPU/GPU/BLAS with pinnings 
```
*** 2395000,2395010 ****
          "intel-openmp >=2025.0.0,<2026.0a0",
          "jinja2",
          "libabseil * cxx17*",
          "libabseil >=20250814.1,<20250815.0a0",
          "libprotobuf >=6.33.0,<6.33.1.0a0",
!         "libtorch 2.8.0.*",
          "libuv >=1.48.0,<2.0a0",
          "mkl >=2025.0.0,<2026.0a0",
          "mkl-service >=2.3.0,<3.0a0",
          "networkx",
          "numpy >=1.23,<3",
--- 2394988,2394998 ----
          "intel-openmp >=2025.0.0,<2026.0a0",
          "jinja2",
          "libabseil * cxx17*",
          "libabseil >=20250814.1,<20250815.0a0",
          "libprotobuf >=6.33.0,<6.33.1.0a0",
!         "libtorch 2.8.0.* *_101",
          "libuv >=1.48.0,<2.0a0",
          "mkl >=2025.0.0,<2026.0a0",
          "mkl-service >=2.3.0,<3.0a0",
          "networkx",
          "numpy >=1.23,<3",
```