### PR TITLE
anaconda-anon-usage <0.7.6 not compatible with conda>=26

### DIFF
--- a/main.py
+++ b/main.py
@@ -1628,16 +1628,24 @@ def patch_record_in_place(fn, record, subdir):
     # anaconda-ident<0.2 not compatible with anaconda-anon-usage
     # anaconda-anon-usage<0.4 not compatible with anaconda-ident
     # anaconda-ident<0.6 not compatible with anaconda-ident >=0.7.2
+    # anaconda-anon-usage<0.7.6 not compatible with conda 2026+
     if name == "anaconda-ident":
         if VersionOrder(version) < VersionOrder("0.2"):
             record["constrains"] = ["anaconda-anon-usage <0"]
         replace_dep(depends, "anaconda-anon-usage >=0.4.1,<1", "anaconda-anon-usage >=0.4.1,<0.7.2")
         replace_dep(depends, "anaconda-anon-usage >=0.6.1,<1", "anaconda-anon-usage >=0.6.1,<0.7.2")
     if name == "anaconda-anon-usage":
+        constrains = record.get("constrains") or []
         if VersionOrder(version) < VersionOrder("0.4"):
-            record["constrains"] = ["anaconda-ident <0"]
-        if VersionOrder(version) < VersionOrder("0.7.2"):
-            record["constrains"] = ["anaconda-ident <0.6.0"]
+            constrains.append("anaconda-ident <0")
+        elif VersionOrder(version) < VersionOrder("0.7.2"):
+            constrains.append("anaconda-ident <0.6.0")
+        # plugin variant only; patch variant already has an upper boound
+        if VersionOrder(version) < VersionOrder("0.7.6"):
+            replace_dep(depends, "conda >=23.7", "conda >=23.7,<26")
+            replace_dep(constrains, "conda >=23.7", "conda >=23.7,<26")
+        if constrains:
+            record["constrains"] = constrains
     # anaconda-auth needs to be paired with anaconda-anon-usage >=0.7.2
     if name == "anaconda-auth":
         if not any(d.startswith("anaconda-anon-usage") for d in depends):


### PR DESCRIPTION
anaconda-anon-usage 0.7.6

**Destination channel:** defaults

### Links

- [PKG-13309](https://anaconda.atlassian.net/browse/PKG-13309) 
- [Upstream repository](https://github.com/anaconda/anaconda-anon-usage)

### Explanation of changes:

- conda 2026 removed a deprecated function that anaconda-anon-usage 0.7.5 and earlier expected to see.


[PKG-13309]: https://anaconda.atlassian.net/browse/PKG-13309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ