### PR TITLE
fix setuptools 82 broken deps

### DIFF
--- a/main.py
+++ b/main.py
@@ -940,32 +940,24 @@ def patch_record_in_place(fn, record, subdir):
     if name == "conda" and "setuptools >=31.0.1" in constrains:
         constrains[:] = [req for req in constrains if not req.startswith("setuptools")]
 
-    _pkg_resources_max_versions = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
-    if name in _pkg_resources_max_versions:
-        max_ver = _pkg_resources_max_versions[name]
-        is_affected_by_setuptools_82_version = VersionOrder(version) <= VersionOrder(max_ver)
-        if is_affected_by_setuptools_82_version:
+    if name in _PKG_RESOURCES_MAX_VERSIONS:
+        if VersionOrder(version) <= VersionOrder(_PKG_RESOURCES_MAX_VERSIONS[name]):
             new_constrains = []
-            capped = False
             for c in constrains:
-                # No setuptools - without changes
                 if not c.startswith("setuptools"):
+                    # Keep as-is
                     new_constrains.append(c)
-                    continue
-                if "<" in c:
-                    # Already has upper bound — without changes
+                elif "<" in c:
+                    # Already has upper bound — keep unchanged
                     new_constrains.append(c)
-                    capped = True
-                elif c.strip() == "setuptools":
-                    # setuptools - add upper-bound
-                    new_constrains.append("setuptools <82")
-                    capped = True
                 else:
-                    # setuptools with lower-bound - append upper-bound
-                    new_constrains.append(c + ",<82")
-                    capped = True
-            if capped:
-                # Add new constrains only if changes were made
+                    # "setuptools"       → "setuptools <82"
+                    # "setuptools >=1"  → "setuptools >=1,<82"
+                    # "setuptools >1"    → "setuptools >1,<82"
+                    # no setuptools in constrains at all → keep unchanged
+                    sep = " " if c.strip() == "setuptools" else ","
+                    new_constrains.append(c + sep + "<82")
+            if new_constrains != constrains:
                 record["constrains"] = new_constrains
 
     # basemap is incompatible with proj/proj4 >=6

--- a/main.py
+++ b/main.py
@@ -298,6 +298,7 @@ SETUPTOOLS_PKG_RESOURCES_VERSIONS = frozenset(
         ("tensorboard", "2.20.0"),
     }
 )
+_PKG_RESOURCES_MAX_VERSIONS = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
 
 MKL_VERSION_2018_RE = re.compile(r">=2018(.\d){0,2}$")
 MKL_VERSION_2018_EXTENDED_RC = re.compile(r">=2018(.\d){0,2}")

--- a/main.py
+++ b/main.py
@@ -944,7 +944,10 @@ def patch_record_in_place(fn, record, subdir):
         "tensorboard": "2.20.0",
     }
     if name in SETUPTOOLS_PKG_RESOURCES_VERSIONS:
-        if VersionOrder(version) <= VersionOrder(SETUPTOOLS_PKG_RESOURCES_VERSIONS[name]):
+        if (
+            VersionOrder(version) <= VersionOrder(SETUPTOOLS_PKG_RESOURCES_VERSIONS[name])
+            and (build[:5] in ["py310", "py311", "py312", "py313", "py314"] or subdir == "noarch")
+        ):
             for i, dep in enumerate(depends):
                 if not dep.startswith("setuptools"):
                     continue

--- a/main.py
+++ b/main.py
@@ -283,7 +283,7 @@ CUDATK_SUBS = {
     "cudatoolkit >=10.0.130,<11.0a0": "cudatoolkit >=10.0.130,<10.1.0a0",
 }
 
-# setuptools >=82 no longer provides pkg_resources; these builds still import it at runtime.
+
 SETUPTOOLS_PKG_RESOURCES_VERSIONS = frozenset(
     {
         ("csvkit", "1.0.5"),
@@ -298,6 +298,37 @@ SETUPTOOLS_PKG_RESOURCES_VERSIONS = frozenset(
         ("tensorboard", "2.20.0"),
     }
 )
+
+_pkg_resources_max_versions = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
+if name in _pkg_resources_max_versions:
+    max_ver = _pkg_resources_max_versions[name]
+
+    is_affected_by_setuptools_82_version = VersionOrder(version) <= VersionOrder(max_ver)
+
+    if is_affected_by_setuptools_82_version:
+        new_constrains = []
+        capped = False
+        for c in constrains:
+            # No setuptools - without changes
+            if not c.startswith("setuptools"):
+                new_constrains.append(c)
+                continue
+            if "<" in c:
+                # Already has upper bound — without changes
+                new_constrains.append(c)
+                capped = True
+            elif c.strip() == "setuptools":
+                # setuptools - add upper-bound
+                new_constrains.append("setuptools <82")
+                capped = True
+            else:
+                # setuptools with lower-bound - append upper-bound
+                new_constrains.append(c + ",<82")
+                capped = True
+        if capped:
+            # Add new constrains only if changes were made
+            record["constrains"] = new_constrains
+
 MKL_VERSION_2018_RE = re.compile(r">=2018(.\d){0,2}$")
 MKL_VERSION_2018_EXTENDED_RC = re.compile(r">=2018(.\d){0,2}")
 LINUX_RUNTIME_RE = re.compile(r"lib(\w+)-ng\s(?:>=)?([\d\.]+\d)(?:$|\.\*)")
@@ -938,11 +969,6 @@ def patch_record_in_place(fn, record, subdir):
     # https://github.com/conda/conda/issues/9337
     if name == "conda" and "setuptools >=31.0.1" in constrains:
         constrains[:] = [req for req in constrains if not req.startswith("setuptools")]
-
-    if (name, version) in SETUPTOOLS_PKG_RESOURCES_VERSIONS:
-        constrains[:] = [c for c in constrains if not c.startswith("setuptools ")]
-        constrains.append("setuptools <82")
-        record["constrains"] = constrains
 
     # basemap is incompatible with proj/proj4 >=6
     # https://github.com/ContinuumIO/anaconda-issues/issues/11590

--- a/main.py
+++ b/main.py
@@ -282,6 +282,22 @@ CUDATK_SUBS = {
     "cudatoolkit >=9.2,<10.0a0": "cudatoolkit >=9.2,<9.3.0a0",
     "cudatoolkit >=10.0.130,<11.0a0": "cudatoolkit >=10.0.130,<10.1.0a0",
 }
+
+# setuptools >=82 no longer provides pkg_resources; these builds still import it at runtime.
+SETUPTOOLS_PKG_RESOURCES_VERSIONS = frozenset(
+    {
+        ("csvkit", "1.0.5"),
+        ("fs", "2.4.16"),
+        ("passlib", "1.7.4"),
+        ("pbr", "6.1.1"),
+        ("picklable-itertools", "0.1.1"),
+        ("pyinstaller", "6.12.0"),
+        ("pyinstaller-hooks-contrib", "2025.1"),
+        ("pyscaffold", "3.3.1"),
+        ("pystan", "3.10.0"),
+        ("tensorboard", "2.20.0"),
+    }
+)
 MKL_VERSION_2018_RE = re.compile(r">=2018(.\d){0,2}$")
 MKL_VERSION_2018_EXTENDED_RC = re.compile(r">=2018(.\d){0,2}")
 LINUX_RUNTIME_RE = re.compile(r"lib(\w+)-ng\s(?:>=)?([\d\.]+\d)(?:$|\.\*)")
@@ -922,6 +938,11 @@ def patch_record_in_place(fn, record, subdir):
     # https://github.com/conda/conda/issues/9337
     if name == "conda" and "setuptools >=31.0.1" in constrains:
         constrains[:] = [req for req in constrains if not req.startswith("setuptools")]
+
+    if (name, version) in SETUPTOOLS_PKG_RESOURCES_VERSIONS:
+        constrains[:] = [c for c in constrains if not c.startswith("setuptools ")]
+        constrains.append("setuptools <82")
+        record["constrains"] = constrains
 
     # basemap is incompatible with proj/proj4 >=6
     # https://github.com/ContinuumIO/anaconda-issues/issues/11590

--- a/main.py
+++ b/main.py
@@ -943,9 +943,7 @@ def patch_record_in_place(fn, record, subdir):
     _pkg_resources_max_versions = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
     if name in _pkg_resources_max_versions:
         max_ver = _pkg_resources_max_versions[name]
-    
         is_affected_by_setuptools_82_version = VersionOrder(version) <= VersionOrder(max_ver)
-    
         if is_affected_by_setuptools_82_version:
             new_constrains = []
             capped = False

--- a/main.py
+++ b/main.py
@@ -299,36 +299,6 @@ SETUPTOOLS_PKG_RESOURCES_VERSIONS = frozenset(
     }
 )
 
-_pkg_resources_max_versions = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
-if name in _pkg_resources_max_versions:
-    max_ver = _pkg_resources_max_versions[name]
-
-    is_affected_by_setuptools_82_version = VersionOrder(version) <= VersionOrder(max_ver)
-
-    if is_affected_by_setuptools_82_version:
-        new_constrains = []
-        capped = False
-        for c in constrains:
-            # No setuptools - without changes
-            if not c.startswith("setuptools"):
-                new_constrains.append(c)
-                continue
-            if "<" in c:
-                # Already has upper bound — without changes
-                new_constrains.append(c)
-                capped = True
-            elif c.strip() == "setuptools":
-                # setuptools - add upper-bound
-                new_constrains.append("setuptools <82")
-                capped = True
-            else:
-                # setuptools with lower-bound - append upper-bound
-                new_constrains.append(c + ",<82")
-                capped = True
-        if capped:
-            # Add new constrains only if changes were made
-            record["constrains"] = new_constrains
-
 MKL_VERSION_2018_RE = re.compile(r">=2018(.\d){0,2}$")
 MKL_VERSION_2018_EXTENDED_RC = re.compile(r">=2018(.\d){0,2}")
 LINUX_RUNTIME_RE = re.compile(r"lib(\w+)-ng\s(?:>=)?([\d\.]+\d)(?:$|\.\*)")
@@ -969,6 +939,36 @@ def patch_record_in_place(fn, record, subdir):
     # https://github.com/conda/conda/issues/9337
     if name == "conda" and "setuptools >=31.0.1" in constrains:
         constrains[:] = [req for req in constrains if not req.startswith("setuptools")]
+
+    _pkg_resources_max_versions = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
+    if name in _pkg_resources_max_versions:
+        max_ver = _pkg_resources_max_versions[name]
+    
+        is_affected_by_setuptools_82_version = VersionOrder(version) <= VersionOrder(max_ver)
+    
+        if is_affected_by_setuptools_82_version:
+            new_constrains = []
+            capped = False
+            for c in constrains:
+                # No setuptools - without changes
+                if not c.startswith("setuptools"):
+                    new_constrains.append(c)
+                    continue
+                if "<" in c:
+                    # Already has upper bound — without changes
+                    new_constrains.append(c)
+                    capped = True
+                elif c.strip() == "setuptools":
+                    # setuptools - add upper-bound
+                    new_constrains.append("setuptools <82")
+                    capped = True
+                else:
+                    # setuptools with lower-bound - append upper-bound
+                    new_constrains.append(c + ",<82")
+                    capped = True
+            if capped:
+                # Add new constrains only if changes were made
+                record["constrains"] = new_constrains
 
     # basemap is incompatible with proj/proj4 >=6
     # https://github.com/ContinuumIO/anaconda-issues/issues/11590

--- a/main.py
+++ b/main.py
@@ -283,23 +283,6 @@ CUDATK_SUBS = {
     "cudatoolkit >=10.0.130,<11.0a0": "cudatoolkit >=10.0.130,<10.1.0a0",
 }
 
-
-SETUPTOOLS_PKG_RESOURCES_VERSIONS = frozenset(
-    {
-        ("csvkit", "1.0.5"),
-        ("fs", "2.4.16"),
-        ("passlib", "1.7.4"),
-        ("pbr", "6.1.1"),
-        ("picklable-itertools", "0.1.1"),
-        ("pyinstaller", "6.12.0"),
-        ("pyinstaller-hooks-contrib", "2025.1"),
-        ("pyscaffold", "3.3.1"),
-        ("pystan", "3.10.0"),
-        ("tensorboard", "2.20.0"),
-    }
-)
-_PKG_RESOURCES_MAX_VERSIONS = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
-
 MKL_VERSION_2018_RE = re.compile(r">=2018(.\d){0,2}$")
 MKL_VERSION_2018_EXTENDED_RC = re.compile(r">=2018(.\d){0,2}")
 LINUX_RUNTIME_RE = re.compile(r"lib(\w+)-ng\s(?:>=)?([\d\.]+\d)(?:$|\.\*)")
@@ -941,25 +924,46 @@ def patch_record_in_place(fn, record, subdir):
     if name == "conda" and "setuptools >=31.0.1" in constrains:
         constrains[:] = [req for req in constrains if not req.startswith("setuptools")]
 
-    if name in _PKG_RESOURCES_MAX_VERSIONS:
-        if VersionOrder(version) <= VersionOrder(_PKG_RESOURCES_MAX_VERSIONS[name]):
-            new_constrains = []
-            for c in constrains:
-                if not c.startswith("setuptools"):
-                    # Keep as-is
-                    new_constrains.append(c)
-                elif "<" in c:
+    ###############################
+    # setuptools 82 compatibility #
+    ###############################
+
+    # In setuptools 82.0.0, the pkg_resources module was removed.
+    # https://github.com/pypa/setuptools/blob/v82.0.0/NEWS.rst#deprecations-and-removals
+    # Below is a list of packages that are affected by this change.
+    _pkg_resources_max_versions = getattr(
+        patch_record_in_place, "_pkg_resources_max_versions", None
+    )
+    if _pkg_resources_max_versions is None:
+        SETUPTOOLS_PKG_RESOURCES_VERSIONS = frozenset(
+            {
+                ("csvkit", "1.0.5"),
+                ("fs", "2.4.16"),
+                ("passlib", "1.7.4"),
+                ("pbr", "6.1.1"),
+                ("picklable-itertools", "0.1.1"),
+                ("pyinstaller", "6.12.0"),
+                ("pyinstaller-hooks-contrib", "2025.1"),
+                ("pyscaffold", "3.3.1"),
+                ("pystan", "3.10.0"),
+                ("tensorboard", "2.20.0"),
+            }
+        )
+        _pkg_resources_max_versions = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
+        patch_record_in_place._pkg_resources_max_versions = _pkg_resources_max_versions
+    if name in _pkg_resources_max_versions:
+        if VersionOrder(version) <= VersionOrder(_pkg_resources_max_versions[name]):
+            for i, dep in enumerate(depends):
+                if not dep.startswith("setuptools"):
+                    continue
+                if "<" in dep:
                     # Already has upper bound — keep unchanged
-                    new_constrains.append(c)
-                else:
-                    # "setuptools"       → "setuptools <82"
-                    # "setuptools >=1"  → "setuptools >=1,<82"
-                    # "setuptools >1"    → "setuptools >1,<82"
-                    # no setuptools in constrains at all → keep unchanged
-                    sep = " " if c.strip() == "setuptools" else ","
-                    new_constrains.append(c + sep + "<82")
-            if new_constrains != constrains:
-                record["constrains"] = new_constrains
+                    continue
+                # "setuptools"       -> "setuptools <82"
+                # "setuptools >=1"   -> "setuptools >=1,<82"
+                # "setuptools >1"    -> "setuptools >1,<82"
+                sep = " " if dep.strip() == "setuptools" else ","
+                depends[i] = dep + sep + "<82"
 
     # basemap is incompatible with proj/proj4 >=6
     # https://github.com/ContinuumIO/anaconda-issues/issues/11590

--- a/main.py
+++ b/main.py
@@ -931,28 +931,20 @@ def patch_record_in_place(fn, record, subdir):
     # In setuptools 82.0.0, the pkg_resources module was removed.
     # https://github.com/pypa/setuptools/blob/v82.0.0/NEWS.rst#deprecations-and-removals
     # Below is a list of packages that are affected by this change.
-    _pkg_resources_max_versions = getattr(
-        patch_record_in_place, "_pkg_resources_max_versions", None
-    )
-    if _pkg_resources_max_versions is None:
-        SETUPTOOLS_PKG_RESOURCES_VERSIONS = frozenset(
-            {
-                ("csvkit", "1.0.5"),
-                ("fs", "2.4.16"),
-                ("passlib", "1.7.4"),
-                ("pbr", "6.1.1"),
-                ("picklable-itertools", "0.1.1"),
-                ("pyinstaller", "6.12.0"),
-                ("pyinstaller-hooks-contrib", "2025.1"),
-                ("pyscaffold", "3.3.1"),
-                ("pystan", "3.10.0"),
-                ("tensorboard", "2.20.0"),
-            }
-        )
-        _pkg_resources_max_versions = dict(SETUPTOOLS_PKG_RESOURCES_VERSIONS)
-        patch_record_in_place._pkg_resources_max_versions = _pkg_resources_max_versions
-    if name in _pkg_resources_max_versions:
-        if VersionOrder(version) <= VersionOrder(_pkg_resources_max_versions[name]):
+    SETUPTOOLS_PKG_RESOURCES_VERSIONS = {
+        "csvkit": "1.0.5",
+        "fs": "2.4.16",
+        "passlib": "1.7.4",
+        "pbr": "6.1.1",
+        "picklable-itertools": "0.1.1",
+        "pyinstaller": "6.12.0",
+        "pyinstaller-hooks-contrib": "2025.1",
+        "pyscaffold": "3.3.1",
+        "pystan": "3.10.0",
+        "tensorboard": "2.20.0",
+    }
+    if name in SETUPTOOLS_PKG_RESOURCES_VERSIONS:
+        if VersionOrder(version) <= VersionOrder(SETUPTOOLS_PKG_RESOURCES_VERSIONS[name]):
             for i, dep in enumerate(depends):
                 if not dep.startswith("setuptools"):
                     continue


### PR DESCRIPTION
https://package-build.anaconda.com/v1/graph/6b10167b-9233-476c-b9d2-3c9d27d52138

```
csvkit-1.0.5
ModuleNotFoundError: No module named 'pkg_resources'

fs-2.4.16
ModuleNotFoundError: No module named 'pkg_resources'

passlib-1.7.4
ModuleNotFoundError: No module named 'pkg_resources'

pbr-6.1.1
ModuleNotFoundError: No module named 'pkg_resources'

picklable-itertools-0.1.1
ModuleNotFoundError: No module named 'pkg_resources'

pyinstaller-6.12.0
ModuleNotFoundError: No module named 'pkg_resources'

pyinstaller-hooks-contrib-2025.1
ModuleNotFoundError: No module named 'pkg_resources'

pyscaffold-3.3.1
ModuleNotFoundError: No module named 'pkg_resources'

pystan-3.10.0
ModuleNotFoundError: No module named 'pkg_resources'

tensorboard-2.20.0
ModuleNotFoundError: No module named 'pkg_resources'
```