### PR TITLE
opentelemetry-api 1.12 using pkg_resources

### DIFF
--- a/main.py
+++ b/main.py
@@ -942,6 +942,7 @@ def patch_record_in_place(fn, record, subdir):
         "pyscaffold": "3.3.1",
         "pystan": "3.10.0",
         "tensorboard": "2.20.0",
+        "opentelemetry-api": "1.12.0",
     }
     if name in SETUPTOOLS_PKG_RESOURCES_VERSIONS:
         if (


### PR DESCRIPTION
https://anaconda.slack.com/archives/C02D68R4D0D/p1776980873885969
```
from opentelemetry import    
     context as context_api\n  File \"<site-packages>/opentelemetry/context/__init__.py\", line 22, in <module>\n
         from pkg_resources import iter_entry_points\nModuleNotFoundError: No module named 'pkg_resources'
```
Fixed in version 1.15.0. In the main channel, only 1.12 was affected.
