### PR TITLE
Update pluggy dependency for conda 26.3.1 compatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -1601,6 +1601,15 @@ def patch_record_in_place(fn, record, subdir):
             if not dep.startswith("conda-anaconda-tos ")
         ] + ["conda-anaconda-tos >=0.2.1"]
 
+    # conda 26.3.1 started using pluggy.HookImpl.wrapper (added in pluggy 1.5.0)
+    # without bumping the recipe's `pluggy >=1.0.0` lower bound, causing
+    # AttributeError: 'HookImpl' object has no attribute 'wrapper' on every
+    # invocation when an older pluggy is installed.
+    # https://github.com/conda/conda/issues/15862
+    # https://github.com/conda/conda/issues/15985
+    if name == "conda" and VersionOrder(version) >= VersionOrder("26.3.1"):
+        replace_dep(depends, "pluggy >=1.0.0", "pluggy >=1.6.0")
+
     if name == "conda-libmamba-solver":
         # libmambapy 0.23 introduced breaking changes
         replace_dep(depends, "libmambapy >=0.22.1", "libmambapy 0.22.*")


### PR DESCRIPTION
conda 26.3.x broke with older versions of pluggy, regression introduced in https://github.com/conda/conda/pull/15840 and not caught in tests.

See https://github.com/conda/conda/pull/15953 for long-term fix. Feedstock update following.