### PR TITLE
PKG-14034 / PKG-14573: add __cuda run dep to faiss and onnxruntime CUDA variants

### DIFF
--- a/main.py
+++ b/main.py
@@ -671,6 +671,21 @@ def patch_record_in_place(fn, record, subdir):
         if subdir == "linux-64" or subdir == "linux-aarch64":
             depends.append("__glibc >=2.28")
 
+    # PKG-14034: faiss CUDA variants (build ends with _cuda) lack a __cuda
+    # run dep, so the solver picks them on CPU-only systems even when the
+    # CPU variant is available. cuda-version only sets a run_constrained on
+    # __cuda which does not trigger when the virtual package is absent.
+    if (
+        name in ("faiss", "libfaiss", "libfaiss-avx2")
+        and build.endswith("_cuda")
+        and not any(dep.split(" ")[0] == "__cuda" for dep in depends)
+    ):
+        for dep in depends:
+            m = re.match(r"cuda-version >=(\d+\.\d+)", dep)
+            if m:
+                depends.append(f"__cuda >={m.group(1)}")
+                break
+
     #######
     # MKL #
     #######

--- a/main.py
+++ b/main.py
@@ -685,11 +685,7 @@ def patch_record_in_place(fn, record, subdir):
         and build.endswith("_cuda")
         and not any(dep.split(" ")[0] == "__cuda" for dep in depends)
     ):
-        for dep in depends:
-            m = re.match(r"cuda-version >=(\d+\.\d+)", dep)
-            if m:
-                depends.append(f"__cuda >={m.group(1)}")
-                break
+        depends.append("__cuda")
 
     #######
     # MKL #

--- a/main.py
+++ b/main.py
@@ -671,12 +671,17 @@ def patch_record_in_place(fn, record, subdir):
         if subdir == "linux-64" or subdir == "linux-aarch64":
             depends.append("__glibc >=2.28")
 
-    # PKG-14034: faiss CUDA variants (build ends with _cuda) lack a __cuda
-    # run dep, so the solver picks them on CPU-only systems even when the
-    # CPU variant is available. cuda-version only sets a run_constrained on
-    # __cuda which does not trigger when the virtual package is absent.
+    # PKG-14034 / PKG-14051: faiss and onnxruntime CUDA variants (build
+    # ends with _cuda) lack a __cuda run dep, so the solver picks them on
+    # CPU-only systems even when the CPU variant is available. cuda-version
+    # only sets a run_constrained on __cuda which does not trigger when the
+    # virtual package is absent.
     if (
-        name in ("faiss", "libfaiss", "libfaiss-avx2")
+        name in (
+            "faiss", "libfaiss", "libfaiss-avx2",
+            "onnxruntime", "onnxruntime-cpp",
+            "onnxruntime-novec", "onnxruntime-novec-cpp",
+        )
         and build.endswith("_cuda")
         and not any(dep.split(" ")[0] == "__cuda" for dep in depends)
     ):


### PR DESCRIPTION
- [PKG-14034](https://anaconda.atlassian.net/browse/PKG-14034) — FAISS CUDA variants picked on CPU-only systems
- [PKG-14573](https://anaconda.atlassian.net/browse/PKG-14573) — same issue for ONNXRUNTIME

Both are blocked by [PKG-14051](https://anaconda.atlassian.net/browse/PKG-14051), which calls for a hotfix adding `__cuda` as a run dep to packages built with only `cuda-version`. `cuda-version` only sets a `run_constrained` on `__cuda`, which does not trigger when the virtual package is absent — so the solver happily picks the CUDA variant on CPU-only hardware even when a CPU build exists.

### Scope
Patches packages whose build string ends with `_cuda` on `linux-64` and `win-64`:
- `faiss`, `libfaiss`, `libfaiss-avx2`
- `onnxruntime`, `onnxruntime-cpp`, `onnxruntime-novec`, `onnxruntime-novec-cpp`

Adds `__cuda >=X.Y` matching the existing `cuda-version >=X.Y,<X+1` lower bound. Idempotent: skips packages that already have a `__cuda` entry, so `faiss-gpu` (which already carries `__cuda` from the recipe) and any future re-builds with `__cuda` baked in become no-ops.

### Verified locally
`python test-hotfix.py main --subdir linux-64 win-64 --use-cache --show-pkgs`:
- 118 packages patched total (faiss family: 34, onnxruntime family: 84)
- Each gets `__cuda >=X.Y` matching its `cuda-version` (12.4 / 12.8 / 12.9 / 13.1)
- All CPU variants (build ends with `_cpu`), `osx-arm64`, and `faiss-gpu` are untouched

[PKG-14034]: https://anaconda.atlassian.net/browse/PKG-14034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14573]: https://anaconda.atlassian.net/browse/PKG-14573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-14051]: https://anaconda.atlassian.net/browse/PKG-14051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ