### PR TITLE
add pybind11-abi dependency to selected artifacts

### DIFF
--- a/main.py
+++ b/main.py
@@ -327,6 +327,73 @@ MISSING_CUDA_VIRTUAL_PACKAGE_VERSION_RANGES = {
     "xformers": ("0.0.30", "0.0.30"),
 }
 
+# https://anaconda.atlassian.net/browse/PKG-13552
+# Add pybind11-abi run dependency to packages built with pybind11 that don't
+# already declare it. The ABI version (4 or 5) is determined by:
+#   - Windows (MSVC) builds            -> 5
+#   - Python >= 3.12 (CPython 3.12+)   -> 5
+#   - Otherwise (Linux/macOS, py<3.12) -> 4
+# Source: pybind11/detail/internals.h PYBIND11_INTERNALS_VERSION macro,
+# mirrored in pybind11-feedstock recipe.
+# Pure C++ outputs (no python dep, e.g. libtorch) cannot have ABI inferred
+# from the build string alone; they are excluded here and left to recipe
+# fixes plus rebuild.
+MISSING_PYBIND11_ABI_VERSION_RANGES = {
+    "contourpy": ("1.0.5", "1.3.3"),
+    "ctranslate2": ("4.7.1", "4.7.1"),
+    "cvxpy": ("1.7.2", "1.8.2"),
+    "cvxpy-base": ("1.7.2", "1.8.2"),
+    "dm-tree": ("0.1.5", "0.1.10"),
+    "duckdb": ("1.2.1", "1.4.3"),
+    "google-re2": ("1.1.20251105", "1.1.20251105"),
+    "highspy": ("1.13.1", "1.13.1"),
+    "iminuit": ("1.2", "2.31.3"),
+    "matplotlib": ("2.0.2", "3.10.9"),
+    "matplotlib-base": ("3.1.2", "3.10.9"),
+    "nmslib": ("2.1.1", "2.1.1"),
+    "onnx": ("1.10.2", "1.20.1"),
+    "onnxruntime": ("1.12.1", "1.24.4"),
+    "onnxruntime-novec": ("1.12.1", "1.24.4"),
+    "optree": ("0.12.1", "0.18.0"),
+    "osqp": ("0.6.3", "1.1.1"),
+    "phik": ("0.10.0", "0.12.5"),
+    "pillow": ("4.2.1", "12.2.0"),
+    "pyamg": ("3.3.2", "5.3.0"),
+    "python-duckdb": ("1.2.1", "1.4.3"),
+    "pytorch": ("0.2.0", "2.11.0"),
+    "qdldl-python": ("0.1.7", "0.1.7.post5"),
+    "scikit-build-core": ("0.6.1", "0.12.2"),
+    "scipy": ("0.19.1", "1.17.1"),
+    "tensorflow": ("1.4.1", "2.21.0"),
+    "tensorflow-base": ("1.4.1", "2.21.0"),
+    "torchaudio": ("2.5.1", "2.10.0"),
+    "torchvision": ("0.2.0", "0.26.0"),
+    "triton": ("3.1.0", "3.6.0"),
+    "whylogs-sketching": ("3.4.1.dev3", "3.4.1.dev3"),
+}
+
+
+def _infer_pybind11_abi(record, subdir):
+    """Return "4", "5", or None if undetermined.
+
+    Determination order:
+      1. Windows always uses ABI 5 (MSVC branch in pybind11).
+      2. Build string contains py3XX -> use that Python minor version.
+      3. depends contains a `python 3.X.*` constraint -> use that.
+      4. Otherwise undetermined (pure C++ output, e.g. libtorch).
+    """
+    if subdir.startswith("win-"):
+        return "5"
+    build = record.get("build", "") or ""
+    m = re.search(r"py3(\d+)", build)
+    if m:
+        return "5" if int(m.group(1)) >= 12 else "4"
+    for dep in record.get("depends", []) or []:
+        dm = re.match(r"^python\s+3\.(\d+)", str(dep))
+        if dm:
+            return "5" if int(dm.group(1)) >= 12 else "4"
+    return None
+
 
 def apply_numpy2_changes(record, subdir, filename):
     """
@@ -708,6 +775,19 @@ def patch_record_in_place(fn, record, subdir):
         and not any(dep.split()[0] == "__cuda" for dep in depends if dep)
     ):
         depends.append("__cuda")
+
+    # https://anaconda.atlassian.net/browse/PKG-13552
+    # add pybind11-abi to packages built with pybind11 that don't declare it,
+    # so they will not be silently mixed with pybind11 v3 (ABI 6).
+    version_range = MISSING_PYBIND11_ABI_VERSION_RANGES.get(name)
+    if (
+        version_range is not None
+        and VersionOrder(version_range[0]) <= VersionOrder(version) <= VersionOrder(version_range[1])
+        and not any(dep.split()[0] == "pybind11-abi" for dep in depends if dep)
+    ):
+        abi = _infer_pybind11_abi(record, subdir)
+        if abi is not None:
+            depends.append(f"pybind11-abi =={abi}")
 
     #######
     # MKL #

--- a/main.py
+++ b/main.py
@@ -368,7 +368,7 @@ MISSING_PYBIND11_ABI_VERSION_RANGES = {
     "tensorflow-base": ("1.4.1", "2.21.0"),
     "torchaudio": ("2.5.1", "2.10.0"),
     "torchvision": ("0.2.0", "0.26.0"),
-    "triton": ("3.1.0", "3.6.0"),
+    "triton": ("3.1.0", "3.7.0"),
     "whylogs-sketching": ("3.4.1.dev3", "3.4.1.dev3"),
 }
 
@@ -778,7 +778,7 @@ def patch_record_in_place(fn, record, subdir):
 
     # https://anaconda.atlassian.net/browse/PKG-13552
     # add pybind11-abi to packages built with pybind11 that don't declare it,
-    # so they will not be silently mixed with pybind11 v3 (ABI 6).
+    # so they will not be silently mixed with pybind11 v3 (ABI 11).
     version_range = MISSING_PYBIND11_ABI_VERSION_RANGES.get(name)
     if (
         version_range is not None

--- a/tests/test_pybind11_abi.py
+++ b/tests/test_pybind11_abi.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+
+"""Tests for the pybind11-abi hotfix (PKG-13552).
+
+Covers:
+- :func:`~main._infer_pybind11_abi` correctness across platforms and build-string shapes.
+- :data:`~main.MISSING_PYBIND11_ABI_VERSION_RANGES` structural integrity.
+- End-to-end patching via :func:`~main.patch_record_in_place` for representative records.
+"""
+
+from __future__ import annotations
+
+__all__ = ()
+
+import typing
+
+import pytest
+
+from conda.models.version import VersionOrder
+
+from main import (
+    MISSING_PYBIND11_ABI_VERSION_RANGES,
+    _infer_pybind11_abi,
+    patch_record_in_place,
+)
+
+
+# ---------------------------------------------------------------------------
+# _infer_pybind11_abi
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    ['subdir', 'build', 'depends', 'expected'],
+    [
+        # Windows always uses ABI 5 (MSVC branch)
+        pytest.param('win-64', 'py310_0', [], '5', id='win-64_py310_msvc'),
+        pytest.param('win-64', 'py311_0', [], '5', id='win-64_py311_msvc'),
+        pytest.param('win-64', 'h0000000_0', [], '5', id='win-64_no_pybuild_still_msvc'),
+
+        # py3XX in build string, Linux/macOS
+        pytest.param('linux-64', 'py313h7010ec8_0', [], '5', id='linux-64_py313'),
+        pytest.param('linux-64', 'py312h7010ec8_0', [], '5', id='linux-64_py312'),
+        pytest.param('linux-64', 'py311h7010ec8_0', [], '4', id='linux-64_py311'),
+        pytest.param('linux-64', 'py310h7010ec8_0', [], '4', id='linux-64_py310'),
+        pytest.param('osx-arm64', 'py314h0000000_0', [], '5', id='osx-arm64_py314'),
+        pytest.param('osx-arm64', 'py39h0000000_0', [], '4', id='osx-arm64_py39'),
+
+        # CUDA-tagged build strings still have py3XX after the cuda prefix
+        pytest.param('linux-64', 'cuda130py312h7010ec8_0', [], '5', id='linux-64_cuda_py312'),
+        pytest.param('linux-64', 'cuda129py310h338dc61_0', [], '4', id='linux-64_cuda_py310'),
+
+        # No py3XX in build, but python pin in depends -> fall back to depends
+        pytest.param('linux-64', 'h12345_0', ['python 3.12.*'], '5', id='depends_python_3_12'),
+        pytest.param('linux-64', 'h12345_0', ['python 3.10.*'], '4', id='depends_python_3_10'),
+        pytest.param('osx-arm64', 'h0_0', ['python 3.13.*', 'numpy'], '5',
+                     id='depends_python_3_13_amid_others'),
+
+        # No py3XX, no python dep (pure C++ outputs like libtorch) -> None
+        pytest.param('linux-64', 'h12345_0', [], None, id='no_python_at_all_linux'),
+        pytest.param('osx-arm64', 'h0_0', ['libstdcxx >=14'], None,
+                     id='no_python_only_native_deps'),
+    ],
+)
+def test_infer_pybind11_abi(
+        subdir: str,
+        build: str,
+        depends: list[str],
+        expected: typing.Optional[str],
+) -> None:
+    """ABI inference matches pybind11/detail/internals.h PYBIND11_INTERNALS_VERSION."""
+    record = {'build': build, 'depends': depends}
+    assert _infer_pybind11_abi(record, subdir) == expected
+
+
+# ---------------------------------------------------------------------------
+# MISSING_PYBIND11_ABI_VERSION_RANGES integrity
+# ---------------------------------------------------------------------------
+
+def test_version_ranges_well_formed() -> None:
+    """Every entry is a (min, max) tuple of strings with min <= max."""
+    for name, value in MISSING_PYBIND11_ABI_VERSION_RANGES.items():
+        assert isinstance(value, tuple) and len(value) == 2, \
+            f"{name}: value must be a (min, max) tuple, got {value!r}"
+        lo, hi = value
+        assert isinstance(lo, str) and isinstance(hi, str), \
+            f"{name}: bounds must be strings, got {value!r}"
+        assert VersionOrder(lo) <= VersionOrder(hi), \
+            f"{name}: lower bound {lo!r} must be <= upper bound {hi!r}"
+
+
+def test_pure_cpp_outputs_excluded() -> None:
+    """Pure C++ outputs (no python dep) must not be in the patch table.
+
+    These cannot have ABI inferred from build string alone; they need a
+    recipe-side fix + rebuild instead. Listed in the patch's docstring.
+    """
+    pure_cpp_outputs = {'libtorch', 'libctranslate2', 'onnxruntime-cpp', 'onnxruntime-novec-cpp'}
+    overlap = pure_cpp_outputs & set(MISSING_PYBIND11_ABI_VERSION_RANGES)
+    assert not overlap, \
+        f"Pure C++ outputs must not be in the patch table: {overlap}"
+
+
+def test_triton_range_covers_released_versions() -> None:
+    """Regression check: triton 3.7.0 (released 2026-05-19) must be in range.
+
+    The original scan was performed before 3.7.0 shipped; if 3.8.0 ships and
+    still lacks pybind11-abi, this test will need updating along with the
+    upper bound.
+    """
+    lo, hi = MISSING_PYBIND11_ABI_VERSION_RANGES['triton']
+    assert VersionOrder(lo) <= VersionOrder('3.7.0') <= VersionOrder(hi)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end via patch_record_in_place
+# ---------------------------------------------------------------------------
+
+def _make_record(name: str, version: str, build: str, depends: list[str]) -> dict:
+    """Build a minimal record dict suitable for patch_record_in_place."""
+    build_number_str = build.rsplit('_', 1)[-1]
+    try:
+        build_number = int(build_number_str)
+    except ValueError:
+        build_number = 0
+    return {
+        'name': name,
+        'version': version,
+        'build': build,
+        'build_number': build_number,
+        'depends': list(depends),
+    }
+
+
+@pytest.mark.parametrize(
+    ['name', 'version', 'build', 'subdir', 'depends', 'expected_abi'],
+    [
+        # Real records the PR description manually verified
+        pytest.param('scipy', '1.17.1', 'py313h0000000_0', 'linux-64',
+                     ['python 3.13.*', 'numpy'], '5',
+                     id='scipy_py313_linux64'),
+        pytest.param('scipy', '1.17.1', 'py311h0000000_0', 'linux-64',
+                     ['python 3.11.*', 'numpy'], '4',
+                     id='scipy_py311_linux64'),
+        pytest.param('scipy', '1.17.1', 'py311h0000000_0', 'win-64',
+                     ['python 3.11.*', 'numpy'], '5',
+                     id='scipy_py311_win64_msvc'),
+        pytest.param('matplotlib-base', '3.10.0', 'py310h0000000_0', 'osx-arm64',
+                     ['python 3.10.*'], '4',
+                     id='matplotlib_base_py310_osx_arm64'),
+        pytest.param('pytorch', '2.11.0', 'cpu_mkl_py313h0000000_0', 'linux-64',
+                     ['python 3.13.*'], '5',
+                     id='pytorch_2_11_cpu_mkl_py313_linux64'),
+        # triton 3.7.0 — explicit regression for the range bump
+        pytest.param('triton', '3.7.0', 'cuda130py312h0000000_0', 'linux-64',
+                     ['python 3.12.*'], '5',
+                     id='triton_3_7_cuda_py312'),
+    ],
+)
+def test_patched_records_gain_pybind11_abi(
+        name: str,
+        version: str,
+        build: str,
+        subdir: str,
+        depends: list[str],
+        expected_abi: str,
+) -> None:
+    """Records in the patch table without pybind11-abi get the right pin appended."""
+    record = _make_record(name, version, build, depends)
+    patch_record_in_place(f'{name}-{version}-{build}.conda', record, subdir)
+    assert f'pybind11-abi =={expected_abi}' in record['depends']
+
+
+def test_idempotent_when_pybind11_abi_already_present() -> None:
+    """Records that already declare pybind11-abi (e.g. mamba pattern) are untouched."""
+    record = _make_record('scipy', '1.17.1', 'py313h0000000_0',
+                          ['python 3.13.*', 'numpy', 'pybind11-abi ==5'])
+    patch_record_in_place('scipy-1.17.1-py313h0000000_0.conda', record, 'linux-64')
+    # exactly one pybind11-abi entry, original preserved
+    abi_deps = [d for d in record['depends'] if d.split()[0] == 'pybind11-abi']
+    assert abi_deps == ['pybind11-abi ==5']
+
+
+def test_not_in_patch_table_unchanged() -> None:
+    """Packages NOT in MISSING_PYBIND11_ABI_VERSION_RANGES get no pybind11-abi."""
+    # mamba is intentionally excluded — it pins pybind11-abi correctly at recipe level
+    record = _make_record('mamba', '1.5.0', 'py312h0000000_0', ['python 3.12.*'])
+    patch_record_in_place('mamba-1.5.0-py312h0000000_0.conda', record, 'linux-64')
+    assert not any(d.split()[0] == 'pybind11-abi' for d in record['depends'])
+
+
+def test_out_of_range_version_unchanged() -> None:
+    """Versions outside the configured range are not patched."""
+    # pytorch range is (0.2.0, 2.11.0); 2.12.0 should NOT be touched.
+    record = _make_record('pytorch', '2.12.0', 'cpu_mkl_py313h0000000_0',
+                          ['python 3.13.*'])
+    patch_record_in_place('pytorch-2.12.0-cpu_mkl_py313h0000000_0.conda', record, 'linux-64')
+    assert not any(d.split()[0] == 'pybind11-abi' for d in record['depends'])
+
+
+def test_undetermined_abi_unchanged() -> None:
+    """If ABI cannot be inferred (no py3XX, no python dep), no pin is added.
+
+    This covers the pure-C++ output case in spirit, even though those names are
+    excluded from the table at the dict level. A defensive double-check.
+    """
+    # Hypothetical: a record that IS in the table but has no python dep.
+    # Should fall through to _infer_pybind11_abi -> None and not be patched.
+    record = _make_record('ctranslate2', '4.7.1', 'h0000000_0', ['libstdcxx >=14'])
+    patch_record_in_place('ctranslate2-4.7.1-h0000000_0.conda', record, 'linux-64')
+    assert not any(d.split()[0] == 'pybind11-abi' for d in record['depends'])


### PR DESCRIPTION
**What changed**
Introduced `MISSING_PYBIND11_ABI_VERSION_RANGES`: a name → (min, max) version map for outputs of the 41 feedstocks identified by the scan attached to [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552) as using pybind11 at build time without declaring `pybind11-abi`. 31 published output names are covered (some of the 41 feedstocks share outputs or aren't on pkgs/main yet).

In `patch_record_in_place`, when all of the following hold:
- the package name and version fall inside the configured range, and
- `depends` does not already include `pybind11-abi`,

append `pybind11-abi ==<N>`, where `N` is inferred per-build via `_infer_pybind11_abi`:

| Condition | ABI |
|---|---|
| Windows builds (MSVC branch) | 5 |
| Build string contains `py3XX`, `XX >= 12` | 5 |
| Build string contains `py3XX`, `XX < 12` | 4 |
| `depends` pins `python 3.X.*`, `X >= 12` | 5 (fallback for non-`py3XX` builds) |
| `depends` pins `python 3.X.*`, `X < 12` | 4 |
| Otherwise (pure C++ output, e.g. libtorch) | skip |

The Python/MSVC split mirrors `pybind11/detail/internals.h`'s `PYBIND11_INTERNALS_VERSION` macro — the same logic [pybind11-feedstock](https://github.com/AnacondaRecipes/pybind11-feedstock/blob/main/recipe/meta.yaml) uses to choose `abi_version` 4 vs 5.

**Rationale**
Before pybind11 v3 (ABI 11 — pybind11 3.0 unified the MSVC and py<3.12 internals counters, so `PYBIND11_INTERNALS_VERSION` jumps from 5 to 11) can be published, currently-released artifacts that were built against pybind11 v2 need to declare their actual ABI so the solver will refuse to mix them with v3-built extensions. This is the hotfix-side of [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552); the recipe-side (adding `pybind11-abi` to host in each feedstock so future builds also declare it) is a separate workstream.

**Excluded from this PR**
Pure C++ outputs that embed pybind11 but have no `python` dep are intentionally excluded:
- `libtorch`
- `libctranslate2`
- `onnxruntime-cpp`, `onnxruntime-novec-cpp`

They need either a recipe fix + rebuild, or a follow-up hotfix that infers ABI from subdir + build toolchain (not Python version).

**Verified locally** against real pkgs/main records (also covered by `tests/test_pybind11_abi.py`):
- `scipy 1.17.1 py313_*` (linux-64) → `pybind11-abi ==5`
- `scipy 1.17.1 py311_*` (linux-64) → `pybind11-abi ==4`
- `scipy 1.17.1 py311_*` (win-64) → `pybind11-abi ==5` (MSVC)
- `matplotlib-base 3.10.* py310_*` (osx-arm64) → `pybind11-abi ==4`
- `pytorch 2.11.0 cpu_mkl_py313_*` (linux-64) → `pybind11-abi ==5`
- `triton 3.7.0 cuda130py312_*` (linux-64) → `pybind11-abi ==5` _(triton 3.7.0 released 2026-05-19 after the original scan; upper bound bumped from 3.6.0 to 3.7.0 in commit 7ee6fb9)_

**Tests added** in `tests/test_pybind11_abi.py` (29 cases, all passing):
- `_infer_pybind11_abi` correctness across MSVC / `py3XX` / `python` pin fallback / pure-C++ skip (16 cases).
- `MISSING_PYBIND11_ABI_VERSION_RANGES` integrity: well-formed tuples, pure-C++ outputs absent, triton range covers 3.7.0.
- End-to-end `patch_record_in_place` flow including idempotence (already-pinned), not-in-table (mamba), out-of-range (pytorch 2.12.0), undetermined-ABI fallthrough.

Jira: [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552)

[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
