### PR TITLE
PKG-13552: reduce pybind11-abi hotfix scope to cross-module ecosystems

### DIFF
--- a/main.py
+++ b/main.py
@@ -338,38 +338,25 @@ MISSING_CUDA_VIRTUAL_PACKAGE_VERSION_RANGES = {
 # Pure C++ outputs (no python dep, e.g. libtorch) cannot have ABI inferred
 # from the build string alone; they are excluded here and left to recipe
 # fixes plus rebuild.
+# Only outputs that exchange pybind11-wrapped C++ types across module boundaries
+# need the abi pin — different-ABI extensions otherwise coexist safely via
+# separate per-DSO internals capsules (see PKG-13552 hotfix-scope analysis).
+# Ecosystems retained here:
+#   - pytorch family: pytorch, torchvision, torchaudio, triton
+#   - onnx family:    onnx, onnxruntime (+novec variant)
+#   - cvxpy family:   cvxpy(-base), osqp, qdldl-python
 MISSING_PYBIND11_ABI_VERSION_RANGES = {
-    "contourpy": ("1.0.5", "1.3.3"),
-    "ctranslate2": ("4.7.1", "4.7.1"),
     "cvxpy": ("1.7.2", "1.8.2"),
     "cvxpy-base": ("1.7.2", "1.8.2"),
-    "dm-tree": ("0.1.5", "0.1.10"),
-    "duckdb": ("1.2.1", "1.4.3"),
-    "google-re2": ("1.1.20251105", "1.1.20251105"),
-    "highspy": ("1.13.1", "1.13.1"),
-    "iminuit": ("1.2", "2.31.3"),
-    "matplotlib": ("2.0.2", "3.10.9"),
-    "matplotlib-base": ("3.1.2", "3.10.9"),
-    "nmslib": ("2.1.1", "2.1.1"),
     "onnx": ("1.10.2", "1.20.1"),
     "onnxruntime": ("1.12.1", "1.24.4"),
     "onnxruntime-novec": ("1.12.1", "1.24.4"),
-    "optree": ("0.12.1", "0.18.0"),
     "osqp": ("0.6.3", "1.1.1"),
-    "phik": ("0.10.0", "0.12.5"),
-    "pillow": ("4.2.1", "12.2.0"),
-    "pyamg": ("3.3.2", "5.3.0"),
-    "python-duckdb": ("1.2.1", "1.4.3"),
     "pytorch": ("0.2.0", "2.11.0"),
     "qdldl-python": ("0.1.7", "0.1.7.post5"),
-    "scikit-build-core": ("0.6.1", "0.12.2"),
-    "scipy": ("0.19.1", "1.17.1"),
-    "tensorflow": ("1.4.1", "2.21.0"),
-    "tensorflow-base": ("1.4.1", "2.21.0"),
     "torchaudio": ("2.5.1", "2.10.0"),
     "torchvision": ("0.2.0", "0.26.0"),
     "triton": ("3.1.0", "3.7.0"),
-    "whylogs-sketching": ("3.4.1.dev3", "3.4.1.dev3"),
 }
 
 

--- a/tests/test_pybind11_abi.py
+++ b/tests/test_pybind11_abi.py
@@ -135,18 +135,18 @@ def _make_record(name: str, version: str, build: str, depends: list[str]) -> dic
     ['name', 'version', 'build', 'subdir', 'depends', 'expected_abi'],
     [
         # Real records the PR description manually verified
-        pytest.param('scipy', '1.17.1', 'py313h0000000_0', 'linux-64',
+        pytest.param('onnxruntime', '1.24.4', 'py313h0000000_0', 'linux-64',
                      ['python 3.13.*', 'numpy'], '5',
-                     id='scipy_py313_linux64'),
-        pytest.param('scipy', '1.17.1', 'py311h0000000_0', 'linux-64',
+                     id='onnxruntime_py313_linux64'),
+        pytest.param('onnxruntime', '1.24.4', 'py311h0000000_0', 'linux-64',
                      ['python 3.11.*', 'numpy'], '4',
-                     id='scipy_py311_linux64'),
-        pytest.param('scipy', '1.17.1', 'py311h0000000_0', 'win-64',
+                     id='onnxruntime_py311_linux64'),
+        pytest.param('onnxruntime', '1.24.4', 'py311h0000000_0', 'win-64',
                      ['python 3.11.*', 'numpy'], '5',
-                     id='scipy_py311_win64_msvc'),
-        pytest.param('matplotlib-base', '3.10.0', 'py310h0000000_0', 'osx-arm64',
+                     id='onnxruntime_py311_win64_msvc'),
+        pytest.param('cvxpy-base', '1.8.2', 'py310h0000000_0', 'osx-arm64',
                      ['python 3.10.*'], '4',
-                     id='matplotlib_base_py310_osx_arm64'),
+                     id='cvxpy_base_py310_osx_arm64'),
         pytest.param('pytorch', '2.11.0', 'cpu_mkl_py313h0000000_0', 'linux-64',
                      ['python 3.13.*'], '5',
                      id='pytorch_2_11_cpu_mkl_py313_linux64'),
@@ -172,9 +172,9 @@ def test_patched_records_gain_pybind11_abi(
 
 def test_idempotent_when_pybind11_abi_already_present() -> None:
     """Records that already declare pybind11-abi (e.g. mamba pattern) are untouched."""
-    record = _make_record('scipy', '1.17.1', 'py313h0000000_0',
+    record = _make_record('onnxruntime', '1.24.4', 'py313h0000000_0',
                           ['python 3.13.*', 'numpy', 'pybind11-abi ==5'])
-    patch_record_in_place('scipy-1.17.1-py313h0000000_0.conda', record, 'linux-64')
+    patch_record_in_place('onnxruntime-1.24.4-py313h0000000_0.conda', record, 'linux-64')
     # exactly one pybind11-abi entry, original preserved
     abi_deps = [d for d in record['depends'] if d.split()[0] == 'pybind11-abi']
     assert abi_deps == ['pybind11-abi ==5']
@@ -205,6 +205,6 @@ def test_undetermined_abi_unchanged() -> None:
     """
     # Hypothetical: a record that IS in the table but has no python dep.
     # Should fall through to _infer_pybind11_abi -> None and not be patched.
-    record = _make_record('ctranslate2', '4.7.1', 'h0000000_0', ['libstdcxx >=14'])
-    patch_record_in_place('ctranslate2-4.7.1-h0000000_0.conda', record, 'linux-64')
+    record = _make_record('osqp', '1.1.1', 'h0000000_0', ['libstdcxx >=14'])
+    patch_record_in_place('osqp-1.1.1-h0000000_0.conda', record, 'linux-64')
     assert not any(d.split()[0] == 'pybind11-abi' for d in record['depends'])


### PR DESCRIPTION
**What changed**

Reduces the `MISSING_PYBIND11_ABI_VERSION_RANGES` table from 31 outputs to 11.
Drops self-contained pybind11 users; keeps only outputs that exchange
pybind11-wrapped C++ types across module boundaries.

| Group | Outputs | Action |
|---|---|---|
| pytorch family | pytorch, torchvision, torchaudio, triton | **kept** |
| onnx family | onnx, onnxruntime, onnxruntime-novec | **kept** |
| cvxpy family | cvxpy, cvxpy-base, osqp, qdldl-python | **kept** |
| Self-contained (Python-native or protocol-level interop) | contourpy, ctranslate2, dm-tree, duckdb, google-re2, highspy, iminuit, matplotlib, matplotlib-base, nmslib, optree, phik, pillow, pyamg, python-duckdb, scikit-build-core, scipy, tensorflow, tensorflow-base, whylogs-sketching | **dropped** |

**Rationale**

pybind11 stores its process-wide type registry in a Python interpreter state
dict keyed by `PYBIND11_INTERNALS_VERSION`. Extensions compiled with
different ABI versions get **completely separate** registries — they share
no state. The worst-case outcome of mixing them is a Python `TypeError`
when one module passes a wrapped C++ object into the other (\"type not
found in registry\"). No crash, no silent corruption.

That failure mode only matters when modules **actually** exchange
pybind11-wrapped types. The retained ecosystems do:

- pytorch ↔ torchvision/torchaudio/triton via wrapped `torch::Tensor` types
- onnx ↔ onnxruntime via wrapped graph/node types
- cvxpy ↔ osqp/qdldl-python via wrapped constraint/problem types

The dropped outputs exchange data via numpy arrays, Python bytes,
lists/dicts, or Python-level protocols (e.g. PyTree's
\`__init_subclass__\`), not via pybind11 type-casters. They coexist
safely with pybind11 v3-built extensions regardless of declared ABI.

Full technical analysis in Charles's [PKG-13552 ticket comment](https://anaconda.atlassian.net/browse/PKG-13552) (2026-05-25).

**Effect on PKG-13552 rebuild plan**

- Original scope: ~26 feedstocks needing rebuild against pybind11 3.0.4
- New scope: ~9 feedstocks (pytorch already in-flight via [pytorch-feedstock#97](https://github.com/AnacondaRecipes/pytorch-feedstock/pull/97); torchvision, torchaudio, triton, cvxpy, osqp, qdldl-python, onnx, onnxruntime remaining)
- The 20 dropped outputs no longer block the pybind11 v3 release

**Tests**

Updated parametrize cases to use kept entries (onnxruntime, cvxpy-base,
osqp) instead of the now-dropped scipy/matplotlib-base/ctranslate2.
All 29 tests pass:

\`\`\`
tests/test_pybind11_abi.py ............................. [100%]
29 passed in 0.14s
\`\`\`

Refs PKG-13552. Follow-up to #316.