### PR TITLE
PKG-13552: drop onnx + onnxruntime + cvxpy + osqp + qdldl-python from pybind11-abi hotfix (false positives)

### DIFF
--- a/main.py
+++ b/main.py
@@ -341,22 +341,22 @@ MISSING_CUDA_VIRTUAL_PACKAGE_VERSION_RANGES = {
 # Only outputs that exchange pybind11-wrapped C++ types across module boundaries
 # need the abi pin — different-ABI extensions otherwise coexist safely via
 # separate per-DSO internals capsules (see PKG-13552 hotfix-scope analysis).
-# Ecosystems retained here:
+# Sole retained ecosystem:
 #   - pytorch family: pytorch, torchvision, torchaudio, triton
-#   - cvxpy family:   cvxpy(-base), osqp, qdldl-python
 #
-# onnx + onnxruntime were dropped (2026-05-27): onnx 1.20.x migrated to
-# nanobind (not pybind11) and onnxruntime vendors pybind11 v3.0.2 (ABI 11)
-# regardless of the system dep. Their cross-module interop goes via protobuf
-# serialization, not via pybind11 type-casters, so the abi pin is unnecessary
-# and was actively wrong (injected ==4/5 onto packages that have ABI 11 or no
-# pybind11 footprint at all).
+# Dropped on 2026-05-27 after upstream code-level verification:
+#   - onnx 1.20.x — migrated to nanobind 2.8.0; no pybind11 footprint at all.
+#   - onnxruntime / onnxruntime-novec — vendors pybind11 v3.0.2 (ABI 11)
+#     regardless of system dep; interop with onnx goes via protobuf, not
+#     pybind11 type-casters.
+#   - cvxpy / cvxpy-base — only pybind11 use is sparsecholesky, which exposes
+#     a free function (m.def) returning std::vector — no py::class_ types.
+#   - osqp — every pybind11 class is declared py::module_local() (explicit
+#     "do not share across modules"). cvxpy↔osqp interop is via scipy.sparse.
+#   - qdldl-python — exports a single PySolver class whose C++ definition is
+#     not shared (no public headers); other modules can't legitimately bind it.
 MISSING_PYBIND11_ABI_VERSION_RANGES = {
-    "cvxpy": ("1.7.2", "1.8.2"),
-    "cvxpy-base": ("1.7.2", "1.8.2"),
-    "osqp": ("0.6.3", "1.1.1"),
     "pytorch": ("0.2.0", "2.11.0"),
-    "qdldl-python": ("0.1.7", "0.1.7.post5"),
     "torchaudio": ("2.5.1", "2.10.0"),
     "torchvision": ("0.2.0", "0.26.0"),
     "triton": ("3.1.0", "3.7.0"),

--- a/main.py
+++ b/main.py
@@ -343,14 +343,17 @@ MISSING_CUDA_VIRTUAL_PACKAGE_VERSION_RANGES = {
 # separate per-DSO internals capsules (see PKG-13552 hotfix-scope analysis).
 # Ecosystems retained here:
 #   - pytorch family: pytorch, torchvision, torchaudio, triton
-#   - onnx family:    onnx, onnxruntime (+novec variant)
 #   - cvxpy family:   cvxpy(-base), osqp, qdldl-python
+#
+# onnx + onnxruntime were dropped (2026-05-27): onnx 1.20.x migrated to
+# nanobind (not pybind11) and onnxruntime vendors pybind11 v3.0.2 (ABI 11)
+# regardless of the system dep. Their cross-module interop goes via protobuf
+# serialization, not via pybind11 type-casters, so the abi pin is unnecessary
+# and was actively wrong (injected ==4/5 onto packages that have ABI 11 or no
+# pybind11 footprint at all).
 MISSING_PYBIND11_ABI_VERSION_RANGES = {
     "cvxpy": ("1.7.2", "1.8.2"),
     "cvxpy-base": ("1.7.2", "1.8.2"),
-    "onnx": ("1.10.2", "1.20.1"),
-    "onnxruntime": ("1.12.1", "1.24.4"),
-    "onnxruntime-novec": ("1.12.1", "1.24.4"),
     "osqp": ("0.6.3", "1.1.1"),
     "pytorch": ("0.2.0", "2.11.0"),
     "qdldl-python": ("0.1.7", "0.1.7.post5"),

--- a/tests/test_pybind11_abi.py
+++ b/tests/test_pybind11_abi.py
@@ -135,15 +135,15 @@ def _make_record(name: str, version: str, build: str, depends: list[str]) -> dic
     ['name', 'version', 'build', 'subdir', 'depends', 'expected_abi'],
     [
         # Real records the PR description manually verified
-        pytest.param('onnxruntime', '1.24.4', 'py313h0000000_0', 'linux-64',
+        pytest.param('cvxpy', '1.8.2', 'py313h0000000_0', 'linux-64',
                      ['python 3.13.*', 'numpy'], '5',
-                     id='onnxruntime_py313_linux64'),
-        pytest.param('onnxruntime', '1.24.4', 'py311h0000000_0', 'linux-64',
+                     id='cvxpy_py313_linux64'),
+        pytest.param('cvxpy', '1.8.2', 'py311h0000000_0', 'linux-64',
                      ['python 3.11.*', 'numpy'], '4',
-                     id='onnxruntime_py311_linux64'),
-        pytest.param('onnxruntime', '1.24.4', 'py311h0000000_0', 'win-64',
+                     id='cvxpy_py311_linux64'),
+        pytest.param('cvxpy', '1.8.2', 'py311h0000000_0', 'win-64',
                      ['python 3.11.*', 'numpy'], '5',
-                     id='onnxruntime_py311_win64_msvc'),
+                     id='cvxpy_py311_win64_msvc'),
         pytest.param('cvxpy-base', '1.8.2', 'py310h0000000_0', 'osx-arm64',
                      ['python 3.10.*'], '4',
                      id='cvxpy_base_py310_osx_arm64'),
@@ -172,9 +172,9 @@ def test_patched_records_gain_pybind11_abi(
 
 def test_idempotent_when_pybind11_abi_already_present() -> None:
     """Records that already declare pybind11-abi (e.g. mamba pattern) are untouched."""
-    record = _make_record('onnxruntime', '1.24.4', 'py313h0000000_0',
+    record = _make_record('cvxpy', '1.8.2', 'py313h0000000_0',
                           ['python 3.13.*', 'numpy', 'pybind11-abi ==5'])
-    patch_record_in_place('onnxruntime-1.24.4-py313h0000000_0.conda', record, 'linux-64')
+    patch_record_in_place('cvxpy-1.8.2-py313h0000000_0.conda', record, 'linux-64')
     # exactly one pybind11-abi entry, original preserved
     abi_deps = [d for d in record['depends'] if d.split()[0] == 'pybind11-abi']
     assert abi_deps == ['pybind11-abi ==5']

--- a/tests/test_pybind11_abi.py
+++ b/tests/test_pybind11_abi.py
@@ -135,18 +135,18 @@ def _make_record(name: str, version: str, build: str, depends: list[str]) -> dic
     ['name', 'version', 'build', 'subdir', 'depends', 'expected_abi'],
     [
         # Real records the PR description manually verified
-        pytest.param('cvxpy', '1.8.2', 'py313h0000000_0', 'linux-64',
-                     ['python 3.13.*', 'numpy'], '5',
-                     id='cvxpy_py313_linux64'),
-        pytest.param('cvxpy', '1.8.2', 'py311h0000000_0', 'linux-64',
-                     ['python 3.11.*', 'numpy'], '4',
-                     id='cvxpy_py311_linux64'),
-        pytest.param('cvxpy', '1.8.2', 'py311h0000000_0', 'win-64',
-                     ['python 3.11.*', 'numpy'], '5',
-                     id='cvxpy_py311_win64_msvc'),
-        pytest.param('cvxpy-base', '1.8.2', 'py310h0000000_0', 'osx-arm64',
-                     ['python 3.10.*'], '4',
-                     id='cvxpy_base_py310_osx_arm64'),
+        pytest.param('torchvision', '0.26.0', 'cuda130py313h0000000_100', 'linux-64',
+                     ['python 3.13.*', 'pytorch 2.11.0', 'numpy'], '5',
+                     id='torchvision_py313_linux64'),
+        pytest.param('torchvision', '0.26.0', 'cpu_py311h0000000_0', 'linux-64',
+                     ['python 3.11.*', 'pytorch 2.11.0', 'numpy'], '4',
+                     id='torchvision_py311_linux64'),
+        pytest.param('torchvision', '0.26.0', 'cpu_py311h0000000_0', 'win-64',
+                     ['python 3.11.*', 'pytorch 2.11.0', 'numpy'], '5',
+                     id='torchvision_py311_win64_msvc'),
+        pytest.param('torchaudio', '2.10.0', 'cpu_py310h0000000_0', 'osx-arm64',
+                     ['python 3.10.*', 'pytorch 2.10.0'], '4',
+                     id='torchaudio_py310_osx_arm64'),
         pytest.param('pytorch', '2.11.0', 'cpu_mkl_py313h0000000_0', 'linux-64',
                      ['python 3.13.*'], '5',
                      id='pytorch_2_11_cpu_mkl_py313_linux64'),
@@ -172,9 +172,9 @@ def test_patched_records_gain_pybind11_abi(
 
 def test_idempotent_when_pybind11_abi_already_present() -> None:
     """Records that already declare pybind11-abi (e.g. mamba pattern) are untouched."""
-    record = _make_record('cvxpy', '1.8.2', 'py313h0000000_0',
-                          ['python 3.13.*', 'numpy', 'pybind11-abi ==5'])
-    patch_record_in_place('cvxpy-1.8.2-py313h0000000_0.conda', record, 'linux-64')
+    record = _make_record('torchvision', '0.26.0', 'cpu_py313h0000000_0',
+                          ['python 3.13.*', 'pytorch 2.11.0', 'numpy', 'pybind11-abi ==5'])
+    patch_record_in_place('torchvision-0.26.0-cpu_py313h0000000_0.conda', record, 'linux-64')
     # exactly one pybind11-abi entry, original preserved
     abi_deps = [d for d in record['depends'] if d.split()[0] == 'pybind11-abi']
     assert abi_deps == ['pybind11-abi ==5']


### PR DESCRIPTION
**What changed**

Removes 7 entries from `MISSING_PYBIND11_ABI_VERSION_RANGES`:

- `onnx`
- `onnxruntime`, `onnxruntime-novec`
- `cvxpy`, `cvxpy-base`
- `osqp`
- `qdldl-python`

Reduces the table from 11 entries to **4** — only the pytorch family remains (`pytorch`, `torchvision`, `torchaudio`, `triton`).

**Rationale**

Upstream code-level verification of each entry showed none participate in cross-module pybind11 C++ type exchange. Charles's original PKG-13552 scope analysis grouped them under "Required (cross-module type exchange)" based on functional descriptions ("exchanges ONNX graph/node types", "exchanges optimization problem types"), but the actual interop turns out to be either via a different binding library (nanobind), via vendored pybind11, via protobuf/scipy.sparse Python objects, or restricted by explicit pybind11 declarations.

### onnx 1.20.x — doesn't use pybind11

[`CMakeLists.txt:427-440`](https://github.com/onnx/onnx/blob/v1.20.1/CMakeLists.txt#L427-L440) shows onnx migrated to **nanobind 2.8.0** (`NB_STATIC NB_DOMAIN onnx STABLE_ABI`). The binary doesn't link against pybind11 at all.

### onnxruntime 1.24.x — vendors pybind11 v3.0.2 (ABI 11)

[`cmake/deps.txt`](https://github.com/microsoft/onnxruntime/blob/v1.24.4/cmake/deps.txt) declares pybind11 v3.0.2, and [`cmake/external/pybind11.cmake`](https://github.com/microsoft/onnxruntime/blob/v1.24.4/cmake/external/pybind11.cmake) uses `FIND_PACKAGE_ARGS 3.0` — falls back to the vendored copy when the system pybind11 doesn't satisfy `>=3.0`. Our recipe's `pybind11 2.13` pin causes that fallback, so the binary's actual ABI is 11 regardless of what the hotfix injected (==4/5).

Cross-module interop with onnx goes via **protobuf serialization** (`ort.InferenceSession(\"model.onnx\")` or `ort.InferenceSession(model.SerializeToString())`), not pybind11 type-casters. Even if they did exchange C++ objects, onnx uses nanobind (separate type registry) — pybind11 ABI mismatch can't even arise.

### osqp 1.1.1 — every pybind11 class is py::module_local()

[`src/bindings.cpp.in`](https://github.com/osqp/osqp-python/blob/v1.1.1/src/bindings.cpp.in):

\`\`\`cpp
py::class_<CSC>(m, \"CSC\", py::module_local())
py::class_<OSQPSettings>(m, \"OSQPSettings\", py::module_local())
py::class_<PyOSQPSolution>(m, \"OSQPSolution\", py::module_local())
py::class_<OSQPInfo>(m, \"OSQPInfo\", py::module_local())
py::class_<PyOSQPSolver>(m, \"OSQPSolver\", py::module_local())
py::class_<OSQPCodegenDefines>(m, \"OSQPCodegenDefines\", py::module_local())
\`\`\`

`py::module_local()` is pybind11's explicit \"do not share this type across modules\" mechanism — a code-level declaration that cross-module C++ type exchange is unsupported.

### qdldl-python 0.1.7.post5 — module-local in practice

[`cpp/wrapper.cpp`](https://github.com/osqp/qdldl-python/blob/v0.1.7.post5/cpp/wrapper.cpp) exports a single `py::class_<PySolver>` without `py::module_local()`, but `PySolver` is defined only in qdldl-python's compiled binary and its headers are not exported. Other modules can't legitimately receive a `PySolver*` because they don't have its declaration.

### cvxpy 1.8.2 — pure procedural pybind11 API

[`cvxpy/utilities/cpp/sparsecholesky/main.cpp`](https://github.com/cvxpy/cvxpy/blob/v1.8.2/cvxpy/utilities/cpp/sparsecholesky/main.cpp):

\`\`\`cpp
PYBIND11_MODULE(_cvxpy_sparsecholesky, m) {
    m.def(\"sparse_chol_from_vecs\", &sparse_chol_from_vecs, ...);
\`\`\`

Only `m.def()` of a single free function taking/returning `std::vector<int/double>`. **No `py::class_` definitions at all.** Nothing to share cross-module.

### How cvxpy ↔ osqp/qdldl/scs/clarabel/highspy actually interop

cvxpy formulates the optimization problem as scipy.sparse matrices (Python-level), then calls the solver's pybind11 binding with those Python objects:

\`\`\`python
P, q, A, l, u = canonicalize(problem)  # all scipy.sparse / numpy
prob = osqp.OSQP()
prob.setup(P, q, A, l, u)  # passes scipy.sparse, NOT pybind11 C++ types
\`\`\`

Each solver's pybind11 binding converts the Python sparse matrices to its own internal C++ structures. No `py::class_`-wrapped types cross module boundaries.

### Effect on pkgs/main and downstream consumers

After the next nightly hotfix run:
- onnx 1.10.2-1.20.1 stops carrying `pybind11-abi ==4/5`
- onnxruntime / onnxruntime-novec 1.12.1-1.24.4 stops carrying it
- cvxpy / cvxpy-base 1.7.2-1.8.2 stops carrying it
- osqp 0.6.3-1.1.1 stops carrying it
- qdldl-python 0.1.7-0.1.7.post5 stops carrying it
- Envs containing any of them + a pybind11-v3 built consumer (pytorch 2.12, etc.) now solve cleanly

### Closed rebuild PRs (now no-ops)

- AnacondaRecipes/onnx-feedstock#22 (PKG-14951)
- AnacondaRecipes/onnxruntime-feedstock#13 (PKG-14952)
- AnacondaRecipes/cvxpy-feedstock#12 (PKG-14953) — closing
- AnacondaRecipes/osqp-feedstock#7 (PKG-14954) — closing
- AnacondaRecipes/qdldl-python-feedstock#6 (PKG-14955) — closing

### Tests

Test parametrize cases updated to use \`torchvision\` / \`torchaudio\` (retained pytorch-family entries) for the realistic patched-record scenarios. 29 tests pass:

\`\`\`
tests/test_pybind11_abi.py ............................. [100%]
29 passed in 0.15s
\`\`\`

Refs PKG-13552. Follow-up to #316 and #318. Updated 2026-05-27 to expand scope after upstream code review of cvxpy/osqp/qdldl-python.