### PR TITLE
ob-metaflow-extensions: python-kubernetes exclusion

### DIFF
--- a/main.py
+++ b/main.py
@@ -2113,6 +2113,14 @@ def patch_record_in_place(fn, record, subdir):
         replace_dep(depends, "rhash >=1.4.1,<2.0a0", "rhash >=1.4.1,<1.4.4a0")
         replace_dep(depends, "rhash >=1.4.3,<2.0a0", "rhash >=1.4.3,<1.4.4a0")
 
+    ##########################
+    # ob-metaflow-extensions #
+    ##########################
+
+    # https://github.com/outerbounds/ob-packages/issues/900
+    if name == "ob-metaflow-extensions":
+        replace_dep(depends, "python-kubernetes", "python-kubernetes !=36.0.0,!=36.0.1")
+
 
 def replace_dep(depends, old, new, *, append=False):
     """


### PR DESCRIPTION
ob-metaflow-extensions

**Destination channel:** defaults

### Links

- [PKG-15149](https://anaconda.atlassian.net/browse/PKG-15149) 
- [Upstream repository](https://github.com/outerbounds/ob-packages)
- Issue: https://github.com/outerbounds/ob-packages/issues/900

### Explanation of changes:

`python-kubernetes` 36.0.0 and 36.0.1 had a breaking API fix that causes the issu above
It was fixed in https://github.com/kubernetes-client/python/pull/2604 and shipped in 36.0.2

> Before v36.0.0, the generated client stored the bearer token under
> api_key['authorization']. v36.0.0 changed the lookup to
> api_key['BearerToken'] without a fallback, so any caller that still
> writes the token under 'authorization' ends up sending requests
> without an Authorization header and gets 401 Unauthorized from the
> API server.
> 
> The user-visible symptom is "everything that used to work with my
> bearer-token kubeconfig now returns 401 against the same cluster after
> upgrading to v36.0.0", on both REST and WebSocket exec paths.

[PKG-15149]: https://anaconda.atlassian.net/browse/PKG-15149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ