### PR TITLE
Add python-jose cryptography<48 hotfix

### DIFF
--- a/main.py
+++ b/main.py
@@ -1151,6 +1151,11 @@ def patch_record_in_place(fn, record, subdir):
         if not any(d.startswith("openssl") for d in depends):
             depends.append("openssl >=3.0.18,<4.0a0")
 
+    # python-jose is unmaintained and incompatible with cryptography >=48
+    # (removed deprecated APIs that python-jose relies on)
+    if name == "python-jose":
+        replace_dep(depends, "cryptography >=3.4.0", "cryptography >=3.4.0,<48")
+
     # intel-openmp requires newer glibc.
     if name == "intel-openmp" and version == "2025.0.0":
         replace_dep(constrains, "__glibc >=2.17", "__glibc >=2.26")


### PR DESCRIPTION
## repodata-hotfix: python-jose cryptography<48

**Destination channel:** defaults

### Links
- [PKG-15168](https://anaconda.atlassian.net/browse/PKG-15168)
- [python-jose on GitHub](https://github.com/mpdavis/python-jose)

### Explanation of changes:
- python-jose relies on deprecated cryptography APIs
- cryptography 48+ removes those APIs, breaking python-jose
- This hotfix adds `cryptography <48` upper bound to existing python-jose artifacts
- Applies to all python-jose packages with `cryptography >=3.4.0` dependency

[PKG-15168]: https://anaconda.atlassian.net/browse/PKG-15168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ