### PR TITLE
hotfix: constrain openssl <3.5.7 for python 3.10/3.11 on win-64

### DIFF
--- a/main.py
+++ b/main.py
@@ -879,9 +879,8 @@ def patch_record_in_place(fn, record, subdir):
     # TODO: Remove once CPython 3.10/3.11 releases a patch that handles
     # malformed Windows store certificates gracefully (as 3.12 does via gh-87005).
     if name == "python" and subdir == "win-64" and version.startswith(("3.10.", "3.11.")):
-        if not any(c.startswith("openssl") for c in constrains):
-            constrains.append("openssl <3.5.7")
-            record["constrains"] = constrains
+        constrains.append("openssl <3.5.7")
+        record["constrains"] = constrains
 
     ################
     # CUDA related #

--- a/main.py
+++ b/main.py
@@ -869,6 +869,22 @@ def patch_record_in_place(fn, record, subdir):
     if name == "python_abi" and version in ["3.10", "3.11", "3.12"] and build_number == 2:
         replace_dep(constrains, f"python {version}.* ^(?!.*_graalpy$)(?!.*_pypy$).*$", f"python {version}.*")
 
+    ##########
+    # python #
+    ##########
+
+    # Python 3.10 and 3.11 on win-64 are incompatible with openssl >=3.5.7.
+    # OpenSSL 3.5.7's stricter ASN1 parser (CVE-2026-34180 fix) causes
+    # _load_windows_store_certs to raise ssl.SSLError on malformed certificates
+    # present in the Windows system certificate store. Python >=3.12 was patched
+    # (gh-87005) to skip malformed certs individually; 3.10 and 3.11 are not.
+    # Restrict until a patched CPython release is available.
+    # See: https://openssl-library.org/news/vulnerabilities/#CVE-2026-34180
+    if name == "python" and subdir == "win-64" and version.startswith(("3.10.", "3.11.")):
+        if not any(c.startswith("openssl") for c in constrains):
+            constrains.append("openssl <3.5.7")
+            record["constrains"] = constrains
+
     ################
     # CUDA related #
     ################

--- a/main.py
+++ b/main.py
@@ -869,10 +869,6 @@ def patch_record_in_place(fn, record, subdir):
     if name == "python_abi" and version in ["3.10", "3.11", "3.12"] and build_number == 2:
         replace_dep(constrains, f"python {version}.* ^(?!.*_graalpy$)(?!.*_pypy$).*$", f"python {version}.*")
 
-    ##########
-    # python #
-    ##########
-
     # Python 3.10 and 3.11 on win-64 are incompatible with openssl >=3.5.7.
     # OpenSSL 3.5.7's stricter ASN1 parser (CVE-2026-34180 fix) causes
     # _load_windows_store_certs to raise ssl.SSLError on malformed certificates

--- a/main.py
+++ b/main.py
@@ -876,6 +876,8 @@ def patch_record_in_place(fn, record, subdir):
     # (gh-87005) to skip malformed certs individually; 3.10 and 3.11 are not.
     # Restrict until a patched CPython release is available.
     # See: https://openssl-library.org/news/vulnerabilities/#CVE-2026-34180
+    # TODO: Remove once CPython 3.10/3.11 releases a patch that handles
+    # malformed Windows store certificates gracefully (as 3.12 does via gh-87005).
     if name == "python" and subdir == "win-64" and version.startswith(("3.10.", "3.11.")):
         if not any(c.startswith("openssl") for c in constrains):
             constrains.append("openssl <3.5.7")


### PR DESCRIPTION
## Problem

OpenSSL 3.5.7 (CVE-2026-34180 fix) introduced a stricter ASN1 parser that causes Python 3.10 and 3.11 builds to crash on Windows with:

```
File "...\ssl.py", line 584, in _load_windows_store_certs
    self.load_verify_locations(cadata=certs)
ssl.SSLError: [ASN1: NOT_ENOUGH_DATA] not enough data (_ssl.c:4040)
```

`_load_windows_store_certs` iterates the Windows system certificate store and passes each cert to OpenSSL. OpenSSL 3.5.7's stricter parser now rejects malformed certificates that the Windows store contains, raising `ssl.SSLError` on the first failure.

**Python >=3.12** was patched ([gh-87005](https://github.com/python/cpython/issues/87005)) to catch and skip individual bad certs — 3.10 and 3.11 are not patched and fail hard.

This is blocking all PBP win-64 builds for py310 and py311.

See: https://openssl-library.org/news/vulnerabilities/#CVE-2026-34180
Slack thread: https://anaconda.slack.com/archives/C03J3NQPS0Z/p1781078532685049

## Fix

Add `constrains: openssl <3.5.7` to all `python 3.10.*` and `python 3.11.*` packages in the `win-64` subdir. The conda solver will refuse to co-install these Python versions with openssl >=3.5.7, forcing a compatible version.

This is a **temporary** fix. It should be removed once a patched CPython 3.10/3.11 release is available that handles the bad certs gracefully.