### PR TITLE
fix woodwork 0.31.0 pkg_resources not found

### DIFF
--- a/main.py
+++ b/main.py
@@ -1249,7 +1249,7 @@ def patch_record_in_place(fn, record, subdir):
     ###############################
 
     # In setuptools 82.0.0, the pkg_resources module was removed.
-    # https://github.com/pypa/setuptools/blob/v81.0.0/NEWS.rst#deprecations-and-removals
+    # https://github.com/pypa/setuptools/blob/v82.0.0/NEWS.rst#deprecations-and-removals
     # Below is a list of packages that are affected by this change.
     SETUPTOOLS_PKG_RESOURCES_VERSIONS = {
         "csvkit": "1.0.5",

--- a/main.py
+++ b/main.py
@@ -1245,11 +1245,11 @@ def patch_record_in_place(fn, record, subdir):
         constrains[:] = [req for req in constrains if not req.startswith("setuptools")]
 
     ###############################
-    # setuptools 82 compatibility #
+    # setuptools 81 compatibility #
     ###############################
 
-    # In setuptools 82.0.0, the pkg_resources module was removed.
-    # https://github.com/pypa/setuptools/blob/v82.0.0/NEWS.rst#deprecations-and-removals
+    # In setuptools 81.0.0, the pkg_resources module was removed.
+    # https://github.com/pypa/setuptools/blob/v81.0.0/NEWS.rst#deprecations-and-removals
     # Below is a list of packages that are affected by this change.
     SETUPTOOLS_PKG_RESOURCES_VERSIONS = {
         "csvkit": "1.0.5",
@@ -1263,6 +1263,7 @@ def patch_record_in_place(fn, record, subdir):
         "pystan": "3.10.0",
         "tensorboard": "2.20.0",
         "opentelemetry-api": "1.12.0",
+        "woodwork": "0.31.0",
     }
     if name in SETUPTOOLS_PKG_RESOURCES_VERSIONS:
         if (
@@ -1275,11 +1276,11 @@ def patch_record_in_place(fn, record, subdir):
                 if "<" in dep:
                     # Already has upper bound — keep unchanged
                     continue
-                # "setuptools"       -> "setuptools <82"
-                # "setuptools >=1"   -> "setuptools >=1,<82"
-                # "setuptools >1"    -> "setuptools >1,<82"
+                # "setuptools"       -> "setuptools <81"
+                # "setuptools >=1"   -> "setuptools >=1,<81"
+                # "setuptools >1"    -> "setuptools >1,<81"
                 sep = " " if dep.strip() == "setuptools" else ","
-                depends[i] = dep + sep + "<82"
+                depends[i] = dep + sep + "<81"
 
     # basemap is incompatible with proj/proj4 >=6
     # https://github.com/ContinuumIO/anaconda-issues/issues/11590

--- a/main.py
+++ b/main.py
@@ -1245,10 +1245,10 @@ def patch_record_in_place(fn, record, subdir):
         constrains[:] = [req for req in constrains if not req.startswith("setuptools")]
 
     ###############################
-    # setuptools 81 compatibility #
+    # setuptools 82 compatibility #
     ###############################
 
-    # In setuptools 81.0.0, the pkg_resources module was removed.
+    # In setuptools 82.0.0, the pkg_resources module was removed.
     # https://github.com/pypa/setuptools/blob/v81.0.0/NEWS.rst#deprecations-and-removals
     # Below is a list of packages that are affected by this change.
     SETUPTOOLS_PKG_RESOURCES_VERSIONS = {
@@ -1276,11 +1276,11 @@ def patch_record_in_place(fn, record, subdir):
                 if "<" in dep:
                     # Already has upper bound — keep unchanged
                     continue
-                # "setuptools"       -> "setuptools <81"
-                # "setuptools >=1"   -> "setuptools >=1,<81"
-                # "setuptools >1"    -> "setuptools >1,<81"
+                # "setuptools"       -> "setuptools <82"
+                # "setuptools >=1"   -> "setuptools >=1,<82"
+                # "setuptools >1"    -> "setuptools >1,<82"
                 sep = " " if dep.strip() == "setuptools" else ","
-                depends[i] = dep + sep + "<81"
+                depends[i] = dep + sep + "<82"
 
     # basemap is incompatible with proj/proj4 >=6
     # https://github.com/ContinuumIO/anaconda-issues/issues/11590


### PR DESCRIPTION
woodwork 0.31.0

**Destination channel:** defaults

### Links

- [PKG-15105](https://anaconda.atlassian.net/browse/PKG-15105) 

### Explanation of changes:

- add upper-bound <81 -> https://taskcluster-prod.s3.us-east-1.amazonaws.com/Pk3f6In5RnGU60KA-V3dCg/1/public/logs/live_backing.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAWUI46DZFCZGHCOQD%2F20260615%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260615T124442Z&X-Amz-Expires=1800&X-Amz-Signature=ad2206b12544032db107bb28c087c499c647cb7ca0b8159adc14bce54a29f8bb&X-Amz-SignedHeaders=host&x-id=GetObject


[PKG-15105]: https://anaconda.atlassian.net/browse/PKG-15105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ