### PR TITLE
Fix conda-lockfiles 0.2.0 conda requirement

### DIFF
--- a/main.py
+++ b/main.py
@@ -1916,6 +1916,9 @@ def patch_record_in_place(fn, record, subdir):
     if name == "conda" and version == "25.9.0":
         replace_dep(depends, "conda-libmamba-solver >=24.11.0", "conda-libmamba-solver >=25.4.0")
 
+    if name == "conda-lockfiles" and version == "0.2.0":
+        replace_dep(depends, "conda >=25.9.0", "conda >=26.3.0")
+
     # Add run constraint for conda to fix plugin here:
     # https://github.com/anaconda/conda-anaconda-telemetry/issues/87
     # https://github.com/anaconda/conda-anaconda-telemetry/pull/96


### PR DESCRIPTION
conda-lockfiles 0.2.0

**Destination channel:** defaults

### Links

- [PKG-16237](https://anaconda.atlassian.net/browse/PKG-16237)
- [Upstream repository](https://github.com/conda/conda-lockfiles)
- [Upstream changelog/diff](https://github.com/conda/conda-lockfiles/compare/0.2.0...0.2.1)
- Relevant dependency PRs:
  - None.

### Explanation of changes:

- Raise the conda dependency for conda-lockfiles 0.2.0 from `>=25.9.0` to `>=26.3.0`.
- conda-lockfiles imports `conda.plugins.types.EnvironmentFormat`, which is not available in conda 25.9.0.


[PKG-16237]: https://anaconda.atlassian.net/browse/PKG-16237?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ