### PR TITLE
Fix mcp breaking changes for version 2.0.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -2288,6 +2288,16 @@ def patch_record_in_place(fn, record, subdir):
             constrains.append("metaflow <0")
             record["constrains"] = constrains
 
+    #########################################
+    # mcp breaking changes on version 2.0.0 #
+    #########################################
+
+    # Tests for claude-agent-sdk failed with mcp 2.0.0
+    # Lowlevel decorators replaced with on_* constructor params
+    # AttributeError: 'Server' object has no attribute 'list_tools' on_* handlers
+    # See https://py.sdk.modelcontextprotocol.io/v2/migration/#changes-almost-every-project-hits
+    if name == "claude-agent-sdk":
+        replace_dep(depends, "mcp >=0.1.0", "mcp >=0.1.0,<2.0.0")
 
 def replace_dep(depends, old, new, *, append=False):
     """

--- a/main.py
+++ b/main.py
@@ -2298,6 +2298,7 @@ def patch_record_in_place(fn, record, subdir):
     # See https://py.sdk.modelcontextprotocol.io/v2/migration/#changes-almost-every-project-hits
     if name == "claude-agent-sdk":
         replace_dep(depends, "mcp >=0.1.0", "mcp >=0.1.0,<2.0.0")
+    # https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver
     if name == "mcp-compose":
         replace_dep(depends, "mcp >=1.2.1", "mcp >=1.2.1,<2.0.0")
 

--- a/main.py
+++ b/main.py
@@ -2299,6 +2299,7 @@ def patch_record_in_place(fn, record, subdir):
     if name == "claude-agent-sdk":
         replace_dep(depends, "mcp >=0.1.0", "mcp >=0.1.0,<2.0.0")
 
+
 def replace_dep(depends, old, new, *, append=False):
     """
     Replace an old dependency with a new one.

--- a/main.py
+++ b/main.py
@@ -2296,10 +2296,10 @@ def patch_record_in_place(fn, record, subdir):
     # Lowlevel decorators replaced with on_* constructor params
     # AttributeError: 'Server' object has no attribute 'list_tools' on_* handlers
     # See https://py.sdk.modelcontextprotocol.io/v2/migration/#changes-almost-every-project-hits
-    if name == "claude-agent-sdk":
+    if name == "claude-agent-sdk" and version == "0.1.45":
         replace_dep(depends, "mcp >=0.1.0", "mcp >=0.1.0,<2.0.0")
     # https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver
-    if name == "mcp-compose":
+    if name == "mcp-compose" and VersionOrder(version) <= VersionOrder("0.1.12"):
         replace_dep(depends, "mcp >=1.2.1", "mcp >=1.2.1,<2.0.0")
 
 

--- a/main.py
+++ b/main.py
@@ -2298,6 +2298,9 @@ def patch_record_in_place(fn, record, subdir):
     # See https://py.sdk.modelcontextprotocol.io/v2/migration/#changes-almost-every-project-hits
     if name == "claude-agent-sdk" and version == "0.1.45":
         replace_dep(depends, "mcp >=0.1.0", "mcp >=0.1.0,<2.0.0")
+    # Tests for mcp-compose failed with mcp 2.0.0
+    # from mcp.server.fastmcp import FastMCP
+    # ModuleNotFoundError: No module named 'mcp.server.fastmcp'
     # https://py.sdk.modelcontextprotocol.io/v2/migration/#fastmcp-renamed-to-mcpserver
     if name == "mcp-compose" and VersionOrder(version) <= VersionOrder("0.1.12"):
         replace_dep(depends, "mcp >=1.2.1", "mcp >=1.2.1,<2.0.0")

--- a/main.py
+++ b/main.py
@@ -2301,6 +2301,7 @@ def patch_record_in_place(fn, record, subdir):
     if name == "mcp-compose":
         replace_dep(depends, "mcp >=1.2.1", "mcp >=1.2.1,<2.0.0")
 
+
 def replace_dep(depends, old, new, *, append=False):
     """
     Replace an old dependency with a new one.

--- a/main.py
+++ b/main.py
@@ -2298,7 +2298,8 @@ def patch_record_in_place(fn, record, subdir):
     # See https://py.sdk.modelcontextprotocol.io/v2/migration/#changes-almost-every-project-hits
     if name == "claude-agent-sdk":
         replace_dep(depends, "mcp >=0.1.0", "mcp >=0.1.0,<2.0.0")
-
+    if name == "mcp-compose":
+        replace_dep(depends, "mcp >=1.2.1", "mcp >=1.2.1,<2.0.0")
 
 def replace_dep(depends, old, new, *, append=False):
     """


### PR DESCRIPTION
mcp 2.0.0

**Destination channel:** defaults

### Links

- [PKG-16797](https://anaconda.atlassian.net/browse/PKG-16797) 
- [Upstream repository](https://github.com/modelcontextprotocol/python-sdk/tree/v2.0.0)
- [pypi ](https://pypi.org/project/mcp/2.0.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/mcp-feedstock/pull/7

### Explanation of changes:

At version 2.0.0, mcp has breaking changes for claude-agent-sdk package, described here:

https://py.sdk.modelcontextprotocol.io/v2/migration/#changes-almost-every-project-hits

Tests are failing with error:

`AttributeError: 'Server' object has no attribute 'list_tools'`


[PKG-16797]: https://anaconda.atlassian.net/browse/PKG-16797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ