### PR TITLE
PKG-17034: paramiko 5.0.0 hotfix

### DIFF
--- a/main.py
+++ b/main.py
@@ -2305,6 +2305,19 @@ def patch_record_in_place(fn, record, subdir):
     if name == "mcp-compose" and VersionOrder(version) <= VersionOrder("0.1.12"):
         replace_dep(depends, "mcp >=1.2.1", "mcp >=1.2.1,<2.0.0")
 
+    ##############################################
+    # paramiko breaking changes on version 4.0.0 #
+    ##############################################
+    # Tests for pysftp failed with paramiko, starting from version 4.0.0
+    # Root cause - not possible to import DSSKey from paramiko:
+    # from paramiko import AgentKey, RSAKey, DSSKey
+    # ImportError: cannot import name 'DSSKey' from 'paramiko'
+
+    # Reason: DSSKey was removed from paramiko in version 4.0.0
+    # See: https://www.paramiko.org/changelog.html#4.0.0
+    if name == "pysftp" and version == "0.2.9":
+        replace_dep(depends, "paramiko >=1.17.0", "paramiko >=1.17.0,<4.0.0")
+
 
 def replace_dep(depends, old, new, *, append=False):
     """


### PR DESCRIPTION
hotfix for pysftp at paramiko 5.0.0

Channels: defaults

### Links

- [PKG-17034](https://anaconda.atlassian.net/browse/PKG-17034) 
- [Upstream repository](https://github.com/paramiko/paramiko/tree/5.0.0)
- [Pypi](https://pypi.org/project/paramiko/5.0.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/paramiko-feedstock/pull/15

### Explanation of changes:

- pysftp tests are failing starting from paramiko version 4.0.0, because DSS support was over starting from this versions - https://www.paramiko.org/changelog.html#4.0.0

### Tests

Graph for downstream tests for paramiko 4.0.0 - https://package-build.anaconda.com/v1/graph/30fcc16c-877c-4a76-99c0-76347afb504d 


[PKG-17034]: https://anaconda.atlassian.net/browse/PKG-17034?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ