### PR TITLE
Hotfix spacy: add explicit click dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -2322,13 +2322,16 @@ def patch_record_in_place(fn, record, subdir):
     # spacy: declare click explicitly (no longer via typer) #
     ##########################################################
     # spacy uses click but historically relied on typer to pull it in.
-    # typer>=0.26 vendors click and no longer depends on the click package, so
-    # solvers (esp. with main-x typer) can omit click and `import spacy` fails:
+    # Only 3.8.11+ allow typer <1.0.0, which can select typer builds that no
+    # longer depend on click (typer 0.20+ on main; typer>=0.26 on main-x), so
+    # solvers can omit click and `import spacy` fails:
     #   ModuleNotFoundError: No module named 'click'
+    # Older spacy builds pin typer below that range and are unaffected.
     # Upstream: https://github.com/explosion/spaCy/commit/dbe520e702e5a8176be2a5fe3cdb65854bb71abf
     # Use >=8.1.8 (not upstream's >=8.2.1) so py39 remains solvable on pkgs/main.
     if (
         name == "spacy"
+        and VersionOrder(version) >= VersionOrder("3.8.11")
         and _has_dep_named(depends, "typer")
         and not _has_dep_named(depends, "click")
     ):

--- a/main.py
+++ b/main.py
@@ -2318,6 +2318,22 @@ def patch_record_in_place(fn, record, subdir):
     if name == "pysftp" and version == "0.2.9":
         replace_dep(depends, "paramiko >=1.17.0", "paramiko >=1.17.0,<4.0.0")
 
+    ##########################################################
+    # spacy: declare click explicitly (no longer via typer) #
+    ##########################################################
+    # spacy uses click but historically relied on typer to pull it in.
+    # typer>=0.26 vendors click and no longer depends on the click package, so
+    # solvers (esp. with main-x typer) can omit click and `import spacy` fails:
+    #   ModuleNotFoundError: No module named 'click'
+    # Upstream: https://github.com/explosion/spaCy/commit/dbe520e702e5a8176be2a5fe3cdb65854bb71abf
+    # Use >=8.1.8 (not upstream's >=8.2.1) so py39 remains solvable on pkgs/main.
+    if (
+        name == "spacy"
+        and _has_dep_named(depends, "typer")
+        and not _has_dep_named(depends, "click")
+    ):
+        depends.append("click >=8.1.8,<9.0.0")
+
 
 def replace_dep(depends, old, new, *, append=False):
     """


### PR DESCRIPTION
## Summary
- spaCy packages on `pkgs/main` that allow `typer <1.0.0` can select typer builds that no longer depend on click (typer 0.20+ on main; typer>=0.26 on main-x), so `import spacy` fails with `ModuleNotFoundError: No module named 'click'`.
- Hotfix: append `click >=8.1.8,<9.0.0` only to **spacy >=3.8.11** records that depend on typer but not click (currently 3.8.11 and 3.8.14). Older spacy builds keep tighter typer upper bounds and are unaffected.
- Lower bound is 8.1.8 (vs upstream's 8.2.1) so py39 remains solvable on pkgs/main.

spaCy’s usage (click.NoSuchOption, click.shell_completion.split_arg_string) already exists in 8.1.8.

**Destination channel:** defaults

## Test plan
- [ ] `python test-hotfix.py main --subdir osx-arm64 linux-64 win-64 --show-pkgs` and confirm only spacy 3.8.11 / 3.8.14 gain `click >=8.1.8,<9.0.0`