### PR TITLE
Hotfix weasel: add explicit click dependency

### DIFF
--- a/main.py
+++ b/main.py
@@ -2337,6 +2337,25 @@ def patch_record_in_place(fn, record, subdir):
     ):
         depends.append("click >=8.1.8,<9.0.0")
 
+    ##########################################################
+    # weasel: declare click explicitly (no longer via typer) #
+    ##########################################################
+    # weasel's CLI is typer-based and historically relied on typer to pull
+    # click in. Builds that allow typer ranges covering versions that no
+    # longer depend on click (typer 0.20+ on main; typer>=0.26 on main-x)
+    # can omit click and break.
+    # 0.3.4 pins typer <0.10.0 (safe). 0.4.3 uses typer-slim, which still
+    # declares click (skipped by the typer-name check below).
+    # 0.4.1 (typer <1.0.0) and 1.0.0 (open typer >=0.3.0) are exposed.
+    # Same pin as the spacy hotfix for py39 solvability on pkgs/main.
+    if (
+        name == "weasel"
+        and VersionOrder(version) >= VersionOrder("0.4.1")
+        and _has_dep_named(depends, "typer")
+        and not _has_dep_named(depends, "click")
+    ):
+        depends.append("click >=8.1.8,<9.0.0")
+
 
 def replace_dep(depends, old, new, *, append=False):
     """


### PR DESCRIPTION
## Summary
- weasel packages on `pkgs/main` that depend on `typer` (not `typer-slim`) can select typer builds that no longer depend on click (typer 0.20+ on main; typer>=0.26 on main-x), so installs can omit click and break.
- Hotfix: append `click >=8.1.8,<9.0.0` only to **weasel >=0.4.1** records that depend on typer but not click (currently 0.4.1 and 1.0.0).
- Skips 0.3.4 (`typer <0.10.0`) and 0.4.3 (`typer-slim`, which still declares click).
- Same lower bound as the spacy hotfix so py39 remains solvable on pkgs/main.

**Destination channel:** defaults

## Test plan
- [x] `python test-hotfix.py main --subdir osx-arm64 linux-64 win-64 --show-pkgs` and confirm only weasel 0.4.1 / 1.0.0 gain `click >=8.1.8,<9.0.0`
- [x] Confirm weasel 0.3.4 and 0.4.3 are unchanged