### PR TITLE
Hotfix conda-build: pin py-lief <1.0 until LIEF 1.0 validated

### DIFF
--- a/main.py
+++ b/main.py
@@ -1408,6 +1408,10 @@ def patch_record_in_place(fn, record, subdir):
             # https://github.com/conda/conda-build/blob/main/CHANGELOG.md#2530-2025-03-17
             if dep_name == "py-lief" and VersionOrder(version) < VersionOrder("25.3.0"):
                 depends[i] = "py-lief <0.15"
+            # LIEF 1.0 not yet validated with conda-build; keep current builds on <1
+            # until https://github.com/conda/conda-build/issues/6085 is resolved.
+            elif dep_name == "py-lief":
+                depends[i] = "py-lief <1.0"
 
     if name == "constructor":
         if int(version[0]) < 3:


### PR DESCRIPTION
## Summary
- `conda-build` depends on unbounded `py-lief`; LIEF 1.0.0 is not yet validated for conda-build ([conda-build#6085](https://github.com/conda/conda-build/issues/6085)).
- Hotfix: for conda-build records that depend on `py-lief` and are **>= 25.3.0**, replace with `py-lief <1.0`.
- conda-build **< 25.3.0** keeps the existing `py-lief <0.15` pin.

**Destination channel:** defaults

## Test plan
- [x] `python test-hotfix.py main --subdirs linux-64 osx-arm64 win-64 --show-pkgs --use-cache`
- [x] Confirm conda-build 25.3.0–26.7.0 gain `py-lief <1.0`
- [x] Confirm older conda-build (<25.3.0) are not switched from the existing `<0.15` pin by this change