### PR TITLE
fix compatibility between cryptography and azure-cli-core 2.85.0

### DIFF
--- a/main.py
+++ b/main.py
@@ -1303,6 +1303,10 @@ def patch_record_in_place(fn, record, subdir):
         if not any(d.startswith("openssl") for d in depends):
             depends.append("openssl >=3.0.18,<4.0a0")
 
+    # azure-cli-core 2.85.0 using hard pin on msal 1.35.1 it is not compatible with the cryptography >=50
+    if name == "azure-cli-core" and version == "2.85.0":
+        replace_dep(depends, "cryptography", "cryptography <50")
+
     # intel-openmp requires newer glibc.
     if name == "intel-openmp" and version == "2025.0.0":
         replace_dep(constrains, "__glibc >=2.17", "__glibc >=2.26")


### PR DESCRIPTION
Fix due to new cryptography 50

https://taskcluster-prod.s3.us-east-1.amazonaws.com/eilHQoZUSCKBbj83ava9fw/0/public/logs/live_backing.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=AKIAWUI46DZFCZGHCOQD%2F20260819%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20260819T072650Z&X-Amz-Expires=1800&X-Amz-Signature=f9cf6bd2807c80b54ddc7d428fb1faf39975f25270c545df8e279c4a4008eb1a&X-Amz-SignedHeaders=host&x-id=GetObject

```
"error": "LibMambaUnsatisfiableError: Encountered problems while solving:\n  - package azure-cli-core-2.85.0-py312h06a4308_0 requires msal 1.35.1, but none of the providers can be installed\n\nCould not solve for environment specs\nThe following packages are incompatible\n\u2514\u2500 azure-cli-core =* * is not installable because there are no viable options\n   \u251c\u2500 azure-cli-core 2.85.0 would require\n   \u2502  \u2514\u2500 msal ==1.35.1 *, which requires\n   \u2502     \u2514\u2500 cryptography >=2.5,<49 *, which conflicts with any installable versions previously reported;\n   \u2514\u2500 azure-cli-core 2.85.0 conflicts with any installable versions previously reported.",
  "exception_name": "LibMambaUnsatisfiableError",
  "exception_type": "<class 'conda_libmamba_solver.exceptions.LibMambaUnsatisfiableError'>",
  "message": "Encountered problems while solving:\n  - package azure-cli-core-2.85.0-py312h06a4308_0 requires msal 1.35.1, but none of the providers can be installed\n\nCould not solve for environment specs\nThe following packages are incompatible\n\u2514\u2500 azure-cli-core =* * is not installable because there are no viable options\n   \u251c\u2500 azure-cli-core 2.85.0 would require\n   \u2502  \u2514\u2500 msal ==1.35.1 *, which requires\n   \u2502     \u2514\u2500 cryptography >=2.5,<49 *, which conflicts with any installable versions previously reported;\n   \u2514\u2500 azure-cli-core 2.85.0 conflicts with any installable versions previously reported."
}
```